### PR TITLE
fixes: Workaround the freeze / crash issue on Android 11 devices

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
             APK_PATH = 'OpenEdXMobile/build/outputs/apk/prod/debuggable'
             CONFIG_REPO_NAME = 'edx-mobile-config'
             TEST_PROJECT_REPO_NAME = 'edx-app-test'
-            AUT_NAME = 'edx-debuggable-3.0.2.apk'
+            AUT_NAME = 'edx-debuggable-3.0.3.apk'
             USER_NAME = credentials('AUTOMATION_USERNAME')
             USER_PASSWORD = credentials('AUTOMATION_PASSWORD')
     }

--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -139,15 +139,7 @@ dependencies {
     // Firebase remote config
     implementation 'com.google.firebase:firebase-config:16.5.0'
 
-    // Add the In-App Messaging dependency:
-    implementation('com.google.firebase:firebase-inappmessaging-display:17.2.0') {
-        // This exclusion has been added due to a conflict between this library and Roboguice
-        // (which has already added the javax.inject group) causing the following error during
-        // compile time: Error: Program type already present: javax.inject.Inject
-        exclude group: 'javax.inject'
-    }
-
-//    Exo Player
+    // Exo Player
     implementation 'com.google.android.exoplayer:exoplayer:2.9.2'
 
     // Google cast sdk


### PR DESCRIPTION
### Description

[LEARNER-8680](https://openedx.atlassian.net/browse/LEARNER-8680)

- The issue is mainly on Xiaomi. The Webviews not loading issue seems to be happening on Xiaomi devices when a VPN is ON with HTTPS filtering also turned to ON.
- For the solution to the crash on Android 11 devices, remove the In-App Messaging SDK altogether from the app.
