### PR TITLE
chore: restrict user to access Special Exam components

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseAPI.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseAPI.java
@@ -392,7 +392,8 @@ public class CourseAPI {
             @NonNull final BlockModel block,
             @NonNull final CourseComponent parent) {
 
-        if (block.isContainer()) {
+        //TODO this(block.specialExamInfo == null) needs to be fixed as this a quick fix for LEARNER-8570
+        if (block.isContainer() && block.specialExamInfo == null) {
             CourseComponent child = new CourseComponent(block, parent);
             for (BlockModel m : courseStructureV1Model.getDescendants(block)) {
                 normalizeCourseStructure(courseStructureV1Model, m, child);


### PR DESCRIPTION

### Description

[LEARNER-8570](https://openedx.atlassian.net/browse/LEARNER-8570)

- Forcefully remove Special-Exam component's descendants from the EnrolledCourseAPI response during parsing