### PR TITLE
feat: Migrate artifacts from JCenter to Maven Central

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -3,9 +3,8 @@ import org.edx.builder.TaskHelper
 buildscript {
     repositories {
         google()
-        jcenter()
         mavenCentral()
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+        maven { url "https://plugins.gradle.org/m2/" }
     }
 
     dependencies {
@@ -17,7 +16,7 @@ buildscript {
         classpath 'com.facebook.testing.screenshot:plugin:0.11.0'
         classpath 'com.google.gms:google-services:4.2.0'
         // Jacoco-android Wrapper : https://github.com/arturdm/jacoco-android-gradle-plugin
-        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
+        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.5'
     }
 }
 
@@ -26,7 +25,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt' //To enable data binding with kotlin
-apply plugin: 'jacoco-android'
+apply plugin: 'com.dicedmelon.gradle.jacoco-android'
 edx {
     platform = ANDROID
 }
@@ -142,7 +141,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-config:16.5.0'
 
     // Exo Player
-    implementation 'com.google.android.exoplayer:exoplayer:2.9.2'
+    implementation 'com.google.android.exoplayer:exoplayer:2.16.0'
 
     // Google cast sdk
     implementation "androidx.mediarouter:mediarouter:$androidXVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ allprojects {
     repositories {
         // The order in which you list these repositories matter.
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://maven.google.com' }
         maven { url 'https://jitpack.io' }
         maven { url "https://appboy.github.io/appboy-android-sdk/sdk" }
@@ -16,8 +16,7 @@ buildscript {
     project.apply from: "${rootDir}/constants.gradle"
     repositories {
         google()
-        jcenter()       // This is the default repo
-        mavenCentral()  //  This is the Maven Central repo
+        mavenCentral()
     }
     dependencies {
         classpath "com.android.tools.build:gradle:$GRADLE_PLUGIN_VERSION"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -22,9 +22,9 @@ subprojects {
         // get picked up. We only have one buildSrc plugin
         // so it doesn't really matter, but if we ever get more
         // we should figure this out
-        compile 'org.codehaus.groovy:groovy-all:2.5.4'
-        compile gradleApi()
-        compile 'org.yaml:snakeyaml:1.14'
+        implementation 'org.codehaus.groovy:groovy-all:2.5.4'
+        implementation gradleApi()
+        implementation 'org.yaml:snakeyaml:1.14'
     }
 }
 


### PR DESCRIPTION
### Description

[LEARNER-8354](https://openedx.atlassian.net/browse/LEARNER-8354)

Migrating from JCenter artifact repository to MavenCentral due to [JCenter service update](https://developer.android.com/studio/build/jcenter-migration).

- Bumping Jacoco to Maven artifact supported release
- Bumping ExoPlayer to latest release because of its dependency
  on JCenter artifact repository
- Bumping AGP to 3.3.3 to support ExoPlayer v2.16.0

### References
**Jacoco**: https://plugins.gradle.org/plugin/com.dicedmelon.gradle.jacoco-android
**ExoPlayer**: https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md
**AGP**: https://stackoverflow.com/a/62969918/10840484