### PR TITLE
fix: Add support for Youtube videos on Android 11 or higher devices

### DIFF
--- a/OpenEdXMobile/AndroidManifest.xml
+++ b/OpenEdXMobile/AndroidManifest.xml
@@ -35,6 +35,12 @@
         android:name="org.edx.mobile.instrumentation.EdxInstrumentation"
         android:targetPackage="org.edx.mobile" />
 
+    <!-- Required for Youtube package visibility on Android 11 or higher devices -->
+    <!-- Inspiration: https://stackoverflow.com/a/66473821/10840484 -->
+    <queries>
+        <package android:name="com.google.android.youtube" />
+    </queries>
+
     <application
         android:name=".base.RuntimeApplication"
         android:allowBackup="true"

--- a/constants.gradle
+++ b/constants.gradle
@@ -1,7 +1,7 @@
 project.ext {
     APPLICATION_ID = "org.edx.mobile"
     KOTLIN_VERSION = "1.3.50"
-    GRADLE_PLUGIN_VERSION = "3.3.2"
+    GRADLE_PLUGIN_VERSION = "3.3.3"
     BUILD_TOOLS_VERSION = "28.0.3"
     COMPILE_SDK_VERSION = 28
     // API Level that the application will target


### PR DESCRIPTION
### Description

[LEARNER-8722](https://openedx.atlassian.net/browse/LEARNER-8722)
    
- For Android 11 or higher devices the PackageManager was returning `NameNotFoundException` for Youtube Android Player API. The main reason was the package visibility of apps installed on the device which was imposed after Android 11 support. This was resolved by adding <queries> element in the manifest file that can be used to add adequate visibility.

- Bumped AGP to 3.3.3 to support <queries> tag in Manifest file
    
### Reference & Inspiration
- https://stackoverflow.com/a/66473821/10840484
- https://developer.android.com/about/versions/11/privacy/package-visibility