### PR TITLE
fix: Remove retained fragment instances after Hilt support

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseSingleFragmentActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseSingleFragmentActivity.java
@@ -77,10 +77,6 @@ public abstract class BaseSingleFragmentActivity extends BaseFragmentActivity im
     private void loadFirstFragment() throws Exception {
         Fragment singleFragment = getFirstFragment();
 
-        //this activity will only ever hold this lone fragment, so we
-        // can afford to retain the instance during activity recreation
-        singleFragment.setRetainInstance(true);
-
         FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
         fragmentTransaction.add(R.id.my_groups_list_container, singleFragment, FIRST_FRAG_TAG);
         fragmentTransaction.disallowAddToBackStack();

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/BaseCourseUnitVideoFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/BaseCourseUnitVideoFragment.java
@@ -162,7 +162,6 @@ public abstract class BaseCourseUnitVideoFragment extends CourseUnitFragment
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setRetainInstance(true);
         unit = getArguments() == null ? null :
                 (VideoBlockModel) getArguments().getSerializable(Router.EXTRA_COURSE_UNIT);
         EventBus.getDefault().registerSticky(this);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsActivity.java
@@ -18,7 +18,6 @@ public class CourseDiscussionCommentsActivity extends BaseSingleFragmentActivity
     @Override
     public Fragment getFirstFragment() {
         commentsFragment.setArguments(getIntent().getExtras());
-        commentsFragment.setRetainInstance(true);
         return commentsFragment;
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionPostsActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionPostsActivity.java
@@ -61,7 +61,6 @@ public class CourseDiscussionPostsActivity extends BaseSingleFragmentActivity {
                     discussionTopic != null);
             fragment.setArguments(args);
         }
-        fragment.setRetainInstance(true);
 
         return fragment;
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesActivity.java
@@ -17,8 +17,6 @@ public class CourseDiscussionResponsesActivity extends BaseSingleFragmentActivit
     @Override
     public Fragment getFirstFragment() {
         courseDiscussionResponsesFragment.setArguments(getIntent().getExtras());
-        courseDiscussionResponsesFragment.setRetainInstance(true);
-
         return courseDiscussionResponsesFragment;
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/EditUserProfileFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/EditUserProfileFragment.java
@@ -112,7 +112,6 @@ public class EditUserProfileFragment extends BaseFragment implements BaseFragmen
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setRetainInstance(true);
         setHasOptionsMenu(true);
         EventBus.getDefault().register(this);
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/PaymentsBannerFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/PaymentsBannerFragment.kt
@@ -59,9 +59,6 @@ class PaymentsBannerFragment : BaseFragment() {
             }
             val fragment: Fragment =
                 newInstance(courseData, courseUnit, courseUpgradeData, showInfoButton)
-            // This activity will only ever hold this lone fragment, so we
-            // can afford to retain the instance during activity recreation
-            fragment.retainInstance = true
             val fragmentTransaction: FragmentTransaction = childFragmentManager.beginTransaction()
             if (animate) {
                 fragmentTransaction.setCustomAnimations(R.anim.slide_up, android.R.anim.fade_out)

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/PaymentsBannerFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/PaymentsBannerFragment.kt
@@ -59,6 +59,9 @@ class PaymentsBannerFragment : BaseFragment() {
             }
             val fragment: Fragment =
                 newInstance(courseData, courseUnit, courseUpgradeData, showInfoButton)
+            // This activity will only ever hold this lone fragment, so we
+            // can afford to retain the instance during activity recreation
+            fragment.retainInstance = true
             val fragmentTransaction: FragmentTransaction = childFragmentManager.beginTransaction()
             if (animate) {
                 fragmentTransaction.setCustomAnimations(R.anim.slide_up, android.R.anim.fade_out)

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/PresenterFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/PresenterFragment.java
@@ -25,11 +25,6 @@ public abstract class PresenterFragment<P extends Presenter<V>, V> extends BaseF
     @Override
     @CallSuper
     public void onCreate(@Nullable Bundle savedInstanceState) {
-        if(getParentFragment() == null) {
-            // retain instance is inherited through the fragment tree
-            // so don't need it for fragments with parents
-            setRetainInstance(true);
-        }
         if (null == presenter) {
             if (getContext().getApplicationContext() instanceof PresenterInjector) {
                 //noinspection unchecked

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/whatsnew/WhatsNewActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/whatsnew/WhatsNewActivity.java
@@ -28,12 +28,7 @@ public class WhatsNewActivity extends BaseFragmentActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_whats_new);
 
-
         Fragment singleFragment = new WhatsNewFragment();
-
-        // This activity will only ever hold this lone fragment, so we
-        // can afford to retain the instance during activity recreation
-        singleFragment.setRetainInstance(true);
 
         FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
         fragmentTransaction.add(R.id.fragment_container, singleFragment, null);

--- a/OpenEdXMobile/src/test/java/org/edx/mobile/view/BaseCourseUnitVideoFragmentTest.java
+++ b/OpenEdXMobile/src/test/java/org/edx/mobile/view/BaseCourseUnitVideoFragmentTest.java
@@ -71,7 +71,6 @@ public abstract class BaseCourseUnitVideoFragmentTest extends UiTest {
     public void initializeTest() {
         final BaseCourseUnitVideoFragment fragment = CourseUnitVideoPlayerFragment.newInstance(getVideoUnit(), false, false);
         SupportFragmentTestUtil.startVisibleFragment(fragment, FragmentUtilActivity.class, 1);
-        assertTrue(fragment.getRetainInstance());
 
         final View view = fragment.getView();
         assertNotNull(view);

--- a/OpenEdXMobile/src/test/java/org/edx/mobile/view/CourseTabsDashboardActivityTest.java
+++ b/OpenEdXMobile/src/test/java/org/edx/mobile/view/CourseTabsDashboardActivityTest.java
@@ -61,7 +61,6 @@ public class CourseTabsDashboardActivityTest extends BaseFragmentActivityTest {
 //                .findFragmentByTag(CourseOutlineFragment.TAG);
 //        assertNotNull(fragment);
 //        assertThat(fragment).isInstanceOf(CourseOutlineFragment.class);
-//        assertTrue(fragment.getRetainInstance());
 //        Bundle args = fragment.getArguments();
 //        assertNotNull(args);
 //        Bundle data = intent.getBundleExtra(Router.EXTRA_BUNDLE);


### PR DESCRIPTION
### Description

[LEARNER-8772](https://openedx.atlassian.net/browse/LEARNER-8772)

- Fragments in Hilt need to be attached to a host activity for injection. 
   Detached fragment injection isn't supported in Hilt.
- Retained Fragment's state will be retained/detached (and not destroyed!) across configuration changes.
- They deprecated setRetainInstance anyway because they prefer ViewModel.

### Inspiration
- https://www.reddit.com/r/android_devs/comments/m8cjts/in_the_hilt_codelabs_its_mentioned_warning_hilt/