### PR TITLE
fix: hide VideoQualityLayout for YouTube Videos

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -784,7 +784,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
     }
 
     private void setUpVideoQualityHeader(CourseComponent courseComponent) {
-        if (isVideoMode && isOnCourseOutline) {
+        if (isVideoMode && isOnCourseOutline && courseComponent.getDownloadableVideosCount() > 0) {
             videoQualityLayout.setVisibility(View.VISIBLE);
             videoQualityLayout.setOnClickListener(v -> {
                 environment.getAnalyticsRegistry().trackEvent(Analytics.Events.COURSE_VIDEOS_VIDEO_DOWNLOAD_QUALITY_CLICKED,


### PR DESCRIPTION
### Description

[LEARNER-8677](https://openedx.atlassian.net/browse/LEARNER-8677)

- Hide VideoQualityLayout for Youtube Videos.