### PR TITLE
build: Enable CI through Github Actions

### DIFF
--- a/.github/workflows/androidTestSuite.yml
+++ b/.github/workflows/androidTestSuite.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   android_test_cases:
     name: Android Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       # Checkouts the current branch for processing
@@ -36,7 +36,7 @@ jobs:
           ./gradlew jacocoTestProdDebugUnitTestReport
           ./gradlew copyUnitTestBuildArtifacts
 
-      # Uploads the folder or file in path to Github
+      # Uploads the folder or file in path to GitHub
       - name: Upload Test Report
         # Run this step even if the previous fails
         if: always()
@@ -47,15 +47,21 @@ jobs:
 
       # Upload the test report to Codecov for coverage report
       - name: Codecov Report
-        run: bash <(curl -s https://codecov.io/bash) -f "artifacts/reports/jacoco/jacocoTestProdDebugUnitTestReport/jacocoTestProdDebugUnitTestReport.xml"
+        uses: codecov/codecov-action@v2
+        with:
+          directory: artifacts
+          files: jacocoTestProdDebugUnitTestReport.xml
+          fail_ci_if_error: true
+          verbose: true
 
   android_screenshot:
-    name: Android Screenshot Tests
+    name: Android Instrumented Tests
     # The macOS VM provided by GitHub Actions has HAXM installed so we are able to create a new AVD
     # instance, launch an emulator with hardware acceleration, and run our Android tests directly
     # on the VM.
+    # Includes Screenshot Tests
     # Ref: https://github.com/marketplace/actions/android-emulator-runner
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
       # Checkouts the current branch for processing
@@ -76,8 +82,8 @@ jobs:
         with:
           python-version: 2.7
 
-      # Install Pillow 6.2.2 for screenshot testing
-      - name: Install Pillow
+      # Install requirements for screenshot testing
+      - name: Install Requirements
         run: pip install -r requirements.txt
 
       # Cache and restore the Gradle dependencies on multiple runs
@@ -95,7 +101,7 @@ jobs:
           key: avd-21
 
       # Create AVD for caching and to be used later
-      - name: Create AVD and generate snapshot for caching
+      - name: Create AVD and generate a snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -124,7 +130,7 @@ jobs:
             ./gradlew pullProdDebuggableAndroidTestScreenshots -PdisablePreDex
             mv OpenEdXMobile/screenshots artifacts/
 
-      # Uploads the folder or file in path to Github
+      # Uploads the folder or file in path to GitHub
       - name: Upload Test Report
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/androidTestSuite.yml
+++ b/.github/workflows/androidTestSuite.yml
@@ -32,7 +32,6 @@ jobs:
       # Run android unit tests & organize test reports
       - name: Run tests
         run: |
-        # Gradle requires executable permission to run some tests
           chmod +x gradlew
           ./gradlew jacocoTestProdDebugUnitTestReport
           ./gradlew copyUnitTestBuildArtifacts

--- a/.github/workflows/androidTestSuite.yml
+++ b/.github/workflows/androidTestSuite.yml
@@ -6,19 +6,48 @@ on:
       - master
 
 jobs:
-  android_ci:
-    name: Android API ${{ matrix.api-level }}
-    runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        api-level: [ 21, 27, 30 ]
+  android_test_cases:
+    name: Android Unit Tests
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup JDK 11
+      - name: Setup JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Gradle cache
+        uses: gradle/gradle-build-action@v2
+
+      - name: Run tests
+        run: |
+          chmod +x gradlew
+          ./gradlew jacocoTestProdDebugUnitTestReport
+          ./gradlew copyUnitTestBuildArtifacts
+
+      - name: Upload Test Report
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Unit Test Report
+          path: artifacts
+
+      - name: Codecov Report
+        run: bash <(curl -s https://codecov.io/bash) -f "artifacts/reports/jacoco/jacocoTestProdDebugUnitTestReport/jacocoTestProdDebugUnitTestReport.xml"
+
+  android_screenshot:
+    name: Android Screenshot Tests
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup JDK
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
@@ -29,11 +58,8 @@ jobs:
         with:
           python-version: 2.7
 
-      - name: Install Pillow and Codecov
-        run: |
-          python -m pip install --upgrade pip
-          pip install --user codecov
-          pip install --user Pillow==6.2.2
+      - name: Install Pillow
+        run: pip install -r requirements.txt
 
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
@@ -45,14 +71,14 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
+          key: avd-21
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           profile: Nexus 4
-          api-level: ${{ matrix.api-level }}
+          api-level: 21
           arch: x86
           target: google_apis
           disable-animations: false
@@ -60,27 +86,11 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           script: echo "Generated AVD snapshot for caching."
 
-      - name: Run tests
-        if: always()
-        uses: ReactiveCircus/android-emulator-runner@v2
-        with:
-          profile: Nexus 4
-          api-level: ${{ matrix.api-level }}
-          arch: x86
-          target: google_apis
-          disable-animations: true
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          script: |
-            chmod +x gradlew
-            ./gradlew jacocoTestProdDebugUnitTestReport
-
       - name: Run E2E
-        if: always()
-        uses: ReactiveCircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@v2
         with:
           profile: Nexus 4
-          api-level: ${{ matrix.api-level }}
+          api-level: 21
           arch: x86
           target: google_apis
           disable-animations: true
@@ -88,39 +98,12 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           script: |
             ./gradlew verifyProdDebuggableAndroidTestScreenshotTest -PdisablePreDex
-
-      - name: Run Artifacts
-        uses: ReactiveCircus/android-emulator-runner@v2
-        with:
-          profile: Nexus 4
-          api-level: ${{ matrix.api-level }}
-          arch: x86
-          target: google_apis
-          disable-animations: true
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          script: |
-            ./gradlew copyLintBuildArtifacts
-            ./gradlew copyUnitTestBuildArtifacts
             ./gradlew pullProdDebuggableAndroidTestScreenshots -PdisablePreDex
-
-      - name: Upload Screenshot Test cases report
-        uses: actions/upload-artifact@v2
-        with:
-          name: report
-          path: OpenEdXMobile/build/screenshotsProdDebuggableAndroidTest
+            mv OpenEdXMobile/screenshots artifacts/
 
       - name: Upload Test Report
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: report
+          name: Screenshot Test Report
           path: artifacts
-
-      - name: Download Test Reports
-        uses: actions/download-artifact@v2
-        with:
-          name: report
-          path: OpenEdXMobile/build/reports/coverage/debug
-
-      - name: Upload Test Report
-        run: bash <(curl -s https://codecov.io/bash) -f "artifacts/reports/jacoco/jacocoTestProdDebugUnitTestReport/jacocoTestProdDebugUnitTestReport.xml"

--- a/.github/workflows/androidTestSuite.yml
+++ b/.github/workflows/androidTestSuite.yml
@@ -1,69 +1,91 @@
 name: Android Test Suite
+
+# The workflow will start for every PR against master branch
 on:
   pull_request:
   push:
     branches:
       - master
 
+# Multiple jobs run in parallel
 jobs:
   android_test_cases:
     name: Android Unit Tests
     runs-on: ubuntu-latest
 
     steps:
+      # Checkouts the current branch for processing
       - name: Checkout
         uses: actions/checkout@v2
 
+      # Setup the Java environment
       - name: Setup JDK
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: '11'
 
+      # Cache and restore the Gradle dependencies on multiple runs
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
 
+      # Run android unit tests & organize test reports
       - name: Run tests
         run: |
+        # Gradle requires executable permission to run some tests
           chmod +x gradlew
           ./gradlew jacocoTestProdDebugUnitTestReport
           ./gradlew copyUnitTestBuildArtifacts
 
+      # Uploads the folder or file in path to Github
       - name: Upload Test Report
+        # Run this step even if the previous fails
         if: always()
         uses: actions/upload-artifact@v2
         with:
           name: Unit Test Report
           path: artifacts
 
+      # Upload the test report to Codecov for coverage report
       - name: Codecov Report
         run: bash <(curl -s https://codecov.io/bash) -f "artifacts/reports/jacoco/jacocoTestProdDebugUnitTestReport/jacocoTestProdDebugUnitTestReport.xml"
 
   android_screenshot:
     name: Android Screenshot Tests
+    # The macOS VM provided by GitHub Actions has HAXM installed so we are able to create a new AVD
+    # instance, launch an emulator with hardware acceleration, and run our Android tests directly
+    # on the VM.
+    # Ref: https://github.com/marketplace/actions/android-emulator-runner
     runs-on: macos-latest
 
     steps:
+      # Checkouts the current branch for processing
       - name: Checkout
         uses: actions/checkout@v2
 
+      # Setup the Java environment
       - name: Setup JDK
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: '11'
 
+      # Install Python 2.7 to support Pillow library for screenshot testing
+      # Ref: https://github.com/facebook/screenshot-tests-for-android#requirements
       - name: Setup Python 2.7
         uses: actions/setup-python@v2
         with:
           python-version: 2.7
 
+      # Install Pillow 6.2.2 for screenshot testing
       - name: Install Pillow
         run: pip install -r requirements.txt
 
+      # Cache and restore the Gradle dependencies on multiple runs
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
 
+      # Cache and restore the particular Android Virtual Device
       - name: AVD cache
         uses: actions/cache@v2
         id: avd-cache
@@ -73,6 +95,7 @@ jobs:
             ~/.android/adb*
           key: avd-21
 
+      # Create AVD for caching and to be used later
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
@@ -86,6 +109,7 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           script: echo "Generated AVD snapshot for caching."
 
+      # Run screenshot test cases and pull the screenshot from device to be used for reporting
       - name: Run E2E
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -101,6 +125,7 @@ jobs:
             ./gradlew pullProdDebuggableAndroidTestScreenshots -PdisablePreDex
             mv OpenEdXMobile/screenshots artifacts/
 
+      # Uploads the folder or file in path to Github
       - name: Upload Test Report
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/androidTestSuite.yml
+++ b/.github/workflows/androidTestSuite.yml
@@ -57,7 +57,7 @@ jobs:
           target: google_apis
           disable-animations: false
           force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -no-boot-anim none
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           script: echo "Generated AVD snapshot for caching."
 
       - name: Run tests
@@ -70,7 +70,7 @@ jobs:
           target: google_apis
           disable-animations: true
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -no-boot-anim none
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           script: |
             chmod +x gradlew
             ./gradlew jacocoTestProdDebugUnitTestReport
@@ -85,7 +85,7 @@ jobs:
           target: google_apis
           disable-animations: true
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -no-boot-anim none
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           script: |
             ./gradlew verifyProdDebuggableAndroidTestScreenshotTest -PdisablePreDex
 
@@ -98,7 +98,7 @@ jobs:
           target: google_apis
           disable-animations: true
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -no-boot-anim none
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           script: |
             ./gradlew copyLintBuildArtifacts
             ./gradlew copyUnitTestBuildArtifacts

--- a/.github/workflows/androidTestSuite.yml
+++ b/.github/workflows/androidTestSuite.yml
@@ -1,0 +1,126 @@
+name: Android Test Suite
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  android_ci:
+    name: Android API ${{ matrix.api-level }}
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        api-level: [ 21, 27, 30 ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Setup Python 2.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 2.7
+
+      - name: Install Pillow and Codecov
+        run: |
+          python -m pip install --upgrade pip
+          pip install --user codecov
+          pip install --user Pillow==6.2.2
+
+      - name: Gradle cache
+        uses: gradle/gradle-build-action@v2
+
+      - name: AVD cache
+        uses: actions/cache@v2
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          profile: Nexus 4
+          api-level: ${{ matrix.api-level }}
+          arch: x86
+          target: google_apis
+          disable-animations: false
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -no-boot-anim none
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: Run tests
+        if: always()
+        uses: ReactiveCircus/android-emulator-runner@v2
+        with:
+          profile: Nexus 4
+          api-level: ${{ matrix.api-level }}
+          arch: x86
+          target: google_apis
+          disable-animations: true
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -no-boot-anim none
+          script: |
+            chmod +x gradlew
+            ./gradlew jacocoTestProdDebugUnitTestReport
+
+      - name: Run E2E
+        if: always()
+        uses: ReactiveCircus/android-emulator-runner@v2
+        with:
+          profile: Nexus 4
+          api-level: ${{ matrix.api-level }}
+          arch: x86
+          target: google_apis
+          disable-animations: true
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -no-boot-anim none
+          script: |
+            ./gradlew verifyProdDebuggableAndroidTestScreenshotTest -PdisablePreDex
+
+      - name: Run Artifacts
+        uses: ReactiveCircus/android-emulator-runner@v2
+        with:
+          profile: Nexus 4
+          api-level: ${{ matrix.api-level }}
+          arch: x86
+          target: google_apis
+          disable-animations: true
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -no-boot-anim none
+          script: |
+            ./gradlew copyLintBuildArtifacts
+            ./gradlew copyUnitTestBuildArtifacts
+            ./gradlew pullProdDebuggableAndroidTestScreenshots -PdisablePreDex
+
+      - name: Upload Screenshot Test cases report
+        uses: actions/upload-artifact@v2
+        with:
+          name: report
+          path: OpenEdXMobile/build/screenshotsProdDebuggableAndroidTest
+
+      - name: Upload Test Report
+        uses: actions/upload-artifact@v2
+        with:
+          name: report
+          path: artifacts
+
+      - name: Download Test Reports
+        uses: actions/download-artifact@v2
+        with:
+          name: report
+          path: OpenEdXMobile/build/reports/coverage/debug
+
+      - name: Upload Test Report
+        run: bash <(curl -s https://codecov.io/bash) -f "artifacts/reports/jacoco/jacocoTestProdDebugUnitTestReport/jacocoTestProdDebugUnitTestReport.xml"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 codecov==2.0.5
-Pillow==8.2.0
+Pillow==6.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
-codecov==2.0.5
+# Python 2.7 ir required to install Pillow library and it supports up to v6.2.2
+# Ref: https://github.com/facebook/screenshot-tests-for-android#requirements
 Pillow==6.2.2
+codecov==2.0.5


### PR DESCRIPTION
### Description

[LEARNER-8778](https://openedx.atlassian.net/browse/LEARNER-8778)

This PR enables CI through Github Actions. We have covered the functionality implemented before via Travis in [travis.yml](https://github.com/openedx/edx-app-android/blob/3bc87ddb8e9fc333155354a6e55220dd90a80738/.travis.yml) file.

The details and reasons to perform some actions are mentioned [here](https://openedx.atlassian.net/browse/LEARNER-8449?focusedCommentId=573274).

### Note
- Checks won't run if the respected branch has merger conflicts
- All the testing and implementation were done in my fork repo first. 
  To see the step-by-step rough implementation process refer here: [HamzaIsrar12/edx-app-android/actions](https://github.com/HamzaIsrar12/edx-app-android/actions).

### References
- Android emulator runner: https://github.com/marketplace/actions/android-emulator-runner
- Codecov: https://github.com/marketplace/actions/codecov
- Workflow syntax: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions