### PR TITLE
feat: Handle respective IAP error messages according to the flow

### DIFF
--- a/OpenEdXMobile/res/values/iap_strings.xml
+++ b/OpenEdXMobile/res/values/iap_strings.xml
@@ -13,9 +13,23 @@
     <!-- Title of Course Upgrade Error Alert -->
     <string name="title_upgrade_error">Upgrade Error</string>
     <!-- Message for course upgrade error -->
-    <string name="upgrade_error_message">It looks like something went wrong when upgrading your course.</string>
+    <string name="general_error_message">It looks like something went wrong when upgrading your course. If this error continues, please contact Support.</string>
     <!-- Email Subject for Course Upgrade Error -->
     <string name="email_subject_upgrade_error">Error upgrading course in app</string>
     <!-- Get Help button label -->
     <string name="label_get_help">Get Help</string>
+
+    <!--  Error Messages  -->
+    <!--  Course didn't found against the course sku in the course upgrade API -->
+    <string name="error_course_not_found">The course you are looking to upgrade could not be found. Please try your upgrade again. If this error continues, contact Support.</string>
+    <!-- Authentication error in course upgrade API's basket, checkout, execute  -->
+    <string name="error_user_not_authenticated">Your account could not be authenticated. Try signing out and signing back into the app. If this error continues, please contact Support.</string>
+    <!--  The course is already upgraded  -->
+    <string name="error_course_already_paid">The course you are looking to upgrade has already been paid for. For additional help, reach out to Support.</string>
+    <!--  Course sku or the payment processor didn't found  -->
+    <string name="error_payment_not_processed">Your payment could not be processed at this time. Please try again. For additional help, reach out to Support.</string>
+    <!--  The native payment is complete but an error occurred while marking the course verified  -->
+    <string name="error_course_not_fullfilled">Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.</string>
+    <!--  The price wasn't fetched from the payment sdk  -->
+    <string name="error_price_not_fetched">Your request could not be completed at this time. If this error continues, please reach out to Support.</string>
 </resources>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/exception/ErrorMessage.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/exception/ErrorMessage.kt
@@ -1,12 +1,15 @@
 package org.edx.mobile.exception
 
+import androidx.annotation.StringRes
+
 /**
  * Error handling model class for ViewModel
  * handle exceptions/error based on errorCode
  */
 data class ErrorMessage(
     val errorCode: Int,
-    val throwable: Throwable
+    val throwable: Throwable,
+    @StringRes val errorResId: Int = 0
 ) {
     companion object {
         // Custom error codes

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/ResponseExt.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/ResponseExt.kt
@@ -1,0 +1,47 @@
+package org.edx.mobile.extenstion
+
+import org.edx.mobile.http.model.NetworkResponseCallback
+import org.edx.mobile.http.model.Result
+import org.edx.mobile.util.InAppPurchasesException
+import org.json.JSONObject
+import retrofit2.Response
+
+/**
+ * Transforms [Response] to [Result] object for In-App Purchases success or error scenarios
+ */
+fun <T> Response<T>.toInAppPurchasesResult(callback: NetworkResponseCallback<T>, apiCode: Int) {
+    when (isSuccessful && body() != null) {
+        true -> callback.onSuccess(
+            Result.Success(
+                isSuccessful = isSuccessful,
+                data = body(),
+                code = code(),
+                message = message()
+            )
+        )
+        false -> callback.onError(
+            Result.Error(
+                InAppPurchasesException(
+                    errorCode = apiCode,
+                    httpErrorCode = code(),
+                    errorMessage = getMessage(),
+                )
+            )
+        )
+    }
+}
+
+/**
+ * Attempts to extract error message from api responses and fails gracefully if unable to do so.
+ *
+ * @return extracted text message; null if no message was received or was unable to parse it.
+ */
+fun <T> Response<T>.getMessage(): String? {
+    if (isSuccessful) return message()
+    return try {
+        val errors = JSONObject(errorBody()?.string() ?: "{}")
+        errors.optString("error")
+    } catch (ex: Exception) {
+        null
+    }
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/repositorie/InAppPurchasesRepository.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/repositorie/InAppPurchasesRepository.kt
@@ -1,5 +1,7 @@
 package org.edx.mobile.repositorie
 
+import org.edx.mobile.exception.ErrorMessage
+import org.edx.mobile.extenstion.toInAppPurchasesResult
 import org.edx.mobile.http.model.NetworkResponseCallback
 import org.edx.mobile.http.model.Result
 import org.edx.mobile.inapppurchases.InAppPurchasesAPI
@@ -18,14 +20,7 @@ class InAppPurchasesRepository(private var iapAPI: InAppPurchasesAPI) {
                 call: Call<AddToBasketResponse>,
                 response: Response<AddToBasketResponse>
             ) {
-                callback.onSuccess(
-                    Result.Success<AddToBasketResponse>(
-                        isSuccessful = response.isSuccessful,
-                        data = response.body(),
-                        code = response.code(),
-                        message = response.message()
-                    )
-                )
+                response.toInAppPurchasesResult(callback, ErrorMessage.ADD_TO_BASKET_CODE)
             }
 
             override fun onFailure(call: Call<AddToBasketResponse>, t: Throwable) {
@@ -40,14 +35,7 @@ class InAppPurchasesRepository(private var iapAPI: InAppPurchasesAPI) {
                 call: Call<CheckoutResponse>,
                 response: Response<CheckoutResponse>
             ) {
-                callback.onSuccess(
-                    Result.Success<CheckoutResponse>(
-                        isSuccessful = response.isSuccessful,
-                        data = response.body(),
-                        code = response.code(),
-                        message = response.message()
-                    )
-                )
+                response.toInAppPurchasesResult(callback, ErrorMessage.CHECKOUT_CODE)
             }
 
             override fun onFailure(call: Call<CheckoutResponse>, t: Throwable) {
@@ -71,14 +59,7 @@ class InAppPurchasesRepository(private var iapAPI: InAppPurchasesAPI) {
                 call: Call<ExecuteOrderResponse>,
                 response: Response<ExecuteOrderResponse>
             ) {
-                callback.onSuccess(
-                    Result.Success<ExecuteOrderResponse>(
-                        isSuccessful = response.isSuccessful,
-                        data = response.body(),
-                        code = response.code(),
-                        message = response.message()
-                    )
-                )
+                response.toInAppPurchasesResult(callback, ErrorMessage.EXECUTE_ORDER_CODE)
             }
 
             override fun onFailure(call: Call<ExecuteOrderResponse>, t: Throwable) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/InAppPurchasesException.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/InAppPurchasesException.kt
@@ -1,0 +1,7 @@
+package org.edx.mobile.util
+
+class InAppPurchasesException(
+    val errorCode: Int,
+    val httpErrorCode: Int,
+    val errorMessage: String?
+) : Exception(errorMessage)

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/InAppPurchasesViewModel.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/InAppPurchasesViewModel.kt
@@ -4,17 +4,15 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.ResponseBody
+import org.edx.mobile.R
 import org.edx.mobile.exception.ErrorMessage
-import org.edx.mobile.http.HttpStatusException
 import org.edx.mobile.http.model.NetworkResponseCallback
 import org.edx.mobile.http.model.Result
 import org.edx.mobile.model.iap.AddToBasketResponse
 import org.edx.mobile.model.iap.CheckoutResponse
 import org.edx.mobile.model.iap.ExecuteOrderResponse
 import org.edx.mobile.repositorie.InAppPurchasesRepository
-import retrofit2.Response
+import org.edx.mobile.util.InAppPurchasesException
 import javax.inject.Inject
 
 @HiltViewModel
@@ -54,12 +52,9 @@ class InAppPurchasesViewModel @Inject constructor(
             productId = productId,
             callback = object : NetworkResponseCallback<AddToBasketResponse> {
                 override fun onSuccess(result: Result.Success<AddToBasketResponse>) {
-                    if (result.isSuccessful && result.data != null) {
-                        proceedCheckout(result.data.basketId)
-                    } else {
-                        setError(ErrorMessage.ADD_TO_BASKET_CODE, result.code, result.message)
-                        endLoading()
-                    }
+                    result.data?.let {
+                        proceedCheckout(it.basketId)
+                    } ?: endLoading()
                 }
 
                 override fun onError(error: Result.Error) {
@@ -75,12 +70,9 @@ class InAppPurchasesViewModel @Inject constructor(
             basketId = basketId,
             callback = object : NetworkResponseCallback<CheckoutResponse> {
                 override fun onSuccess(result: Result.Success<CheckoutResponse>) {
-                    if (result.isSuccessful && result.data != null) {
-                        _checkoutResponse.value = result.data
-                    } else {
-                        setError(ErrorMessage.CHECKOUT_CODE, result.code, result.message)
-                        endLoading()
-                    }
+                    result.data?.let {
+                        _checkoutResponse.value = it
+                    } ?: endLoading()
                 }
 
                 override fun onError(error: Result.Error) {
@@ -97,11 +89,9 @@ class InAppPurchasesViewModel @Inject constructor(
             purchaseToken = purchaseToken,
             callback = object : NetworkResponseCallback<ExecuteOrderResponse> {
                 override fun onSuccess(result: Result.Success<ExecuteOrderResponse>) {
-                    if (result.isSuccessful && result.data != null) {
-                        _executeOrderResponse.value = result.data
+                    result.data?.let {
+                        _executeOrderResponse.value = it
                         orderExecuted()
-                    } else {
-                        setError(ErrorMessage.EXECUTE_ORDER_CODE, result.code, result.message)
                     }
                     endLoading()
                 }
@@ -113,20 +103,8 @@ class InAppPurchasesViewModel @Inject constructor(
             })
     }
 
-    fun setError(errorCode: Int, httpStatusCode: Int, msg: String) {
-        setError(
-            errorCode,
-            HttpStatusException(
-                Response.error<Any>(
-                    httpStatusCode,
-                    ResponseBody.create("text/plain".toMediaTypeOrNull(), msg)
-                )
-            )
-        )
-    }
-
     fun setError(errorCode: Int, throwable: Throwable) {
-        _errorMessage.value = ErrorMessage(errorCode, throwable)
+        _errorMessage.value = ErrorMessage(errorCode, throwable, getErrorMessage(throwable))
     }
 
     fun errorMessageShown() {
@@ -136,5 +114,24 @@ class InAppPurchasesViewModel @Inject constructor(
     private fun orderExecuted() {
         this.productId = ""
         this.basketId = 0
+    }
+
+    private fun getErrorMessage(throwable: Throwable) = if (throwable is InAppPurchasesException) {
+        when (throwable.httpErrorCode) {
+            400 -> when (throwable.errorCode) {
+                ErrorMessage.ADD_TO_BASKET_CODE -> R.string.error_course_not_found
+                ErrorMessage.CHECKOUT_CODE -> R.string.error_payment_not_processed
+                ErrorMessage.EXECUTE_ORDER_CODE -> R.string.error_course_not_fullfilled
+                else -> R.string.general_error_message
+            }
+            403 -> when (throwable.errorCode) {
+                ErrorMessage.EXECUTE_ORDER_CODE -> R.string.error_course_not_fullfilled
+                else -> R.string.error_user_not_authenticated
+            }
+            406 -> R.string.error_course_already_paid
+            else -> R.string.general_error_message
+        }
+    } else {
+        R.string.general_error_message
     }
 }


### PR DESCRIPTION
### Description

[LEARNER-8756](https://openedx.atlassian.net/browse/LEARNER-8756)

-  Includes all the new error messages of the IAP flow mentioned in [figma](https://www.figma.com/file/SFpqDv2FVf2RRV56ATEakH/Payments?node-id=2562%3A3031) 
- The retry option flow is not part of the scope of this ticker and will be done separately