### PR TITLE
build: Point commitlint GitHub action workflow from edx to openEdX

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   commitlint:
-    uses: edx/.github/.github/workflows/commitlint.yml@master
+    uses: openedx/.github/.github/workflows/commitlint.yml@master


### PR DESCRIPTION
### Description

[LEARNER-8803](https://openedx.atlassian.net/browse/LEARNER-8803)

After the migration of GitHub repositories from edX org to OpenEdX org, all custom GitHub actions in workflows should also point to the OpenEdx instance instead of edX.
