### PR TITLE
feat: Send IAP Error Details in Support Email

### DIFF
--- a/OpenEdXMobile/res/values/iap_strings.xml
+++ b/OpenEdXMobile/res/values/iap_strings.xml
@@ -11,7 +11,7 @@
     <string name="purchase_success_message">Thank you for your purchase. Enjoy full access to your course!</string>
 
     <!-- Title of Course Upgrade Error Alert -->
-    <string name="title_upgrade_error">Upgrade Error</string>
+    <string name="title_upgrade_error">An error occurred</string>
     <!-- Message for course upgrade error -->
     <string name="general_error_message">It looks like something went wrong when upgrading your course. If this error continues, please contact Support.</string>
     <!-- Email Subject for Course Upgrade Error -->

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/exception/ErrorMessage.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/exception/ErrorMessage.kt
@@ -20,5 +20,6 @@ data class ErrorMessage(
         const val ADD_TO_BASKET_CODE = 0x201
         const val CHECKOUT_CODE = 0x202
         const val EXECUTE_ORDER_CODE = 0x203
+        const val PAYMENT_SDK_CODE = 0x204
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/BillingProcessor.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/BillingProcessor.kt
@@ -82,7 +82,7 @@ class BillingProcessor(val context: Context, val listener: BillingFlowListeners?
         if (purchases != null && !purchases[0].isAcknowledged) {
             acknowledgePurchase(purchases[0])
         } else if (purchases == null) {
-            listener?.onPurchaseCancel()
+            listener?.onPurchaseCancel(billingResult.responseCode, billingResult.debugMessage)
         }
     }
 
@@ -182,7 +182,7 @@ class BillingProcessor(val context: Context, val listener: BillingFlowListeners?
 
         fun onBillingSetupFinished(billingResult: BillingResult) {}
 
-        fun onPurchaseCancel()
+        fun onPurchaseCancel(responseCode: Int, message: String)
 
         fun onPurchaseComplete(purchase: Purchase)
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/TextUtils.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/TextUtils.java
@@ -14,10 +14,13 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
+import androidx.fragment.app.FragmentActivity;
 
 import org.edx.mobile.R;
+import org.edx.mobile.exception.ErrorMessage;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -183,5 +186,42 @@ public class TextUtils {
             return context.getResources().getQuantityString(R.plurals.video_duration_minutes, mins, mins);
         }
         return String.format("%s %s", context.getResources().getQuantityString(R.plurals.video_duration_hour, hours, hours), context.getResources().getQuantityString(R.plurals.video_duration_minutes, mins, mins));
+    }
+
+    /**
+     * Returns a StringBuilder containing the formatted error message.
+     * i.e Error: error_endpoint-error_code-error_message
+     *
+     * @param activity      Activity object to use for obtaining strings from strings.xml.
+     * @param errorCode     HTTP or SDK response code
+     * @param errorEndpoint Call endpoint
+     * @param errorMessage  Error message from HTTP call or SDK
+     * @return Formatted error message.
+     */
+    public static StringBuilder getFormattedErrorMessage(
+            @NonNull FragmentActivity activity,
+            Integer errorCode,
+            Integer errorEndpoint,
+            String errorMessage) {
+        final String NEW_LINE = "\n";
+        StringBuilder body = new StringBuilder();
+        if (errorEndpoint == null || errorCode == null) return body;
+
+        String endpoint;
+        if (errorEndpoint == ErrorMessage.ADD_TO_BASKET_CODE)
+            endpoint = "basket";
+        else if (errorEndpoint == ErrorMessage.CHECKOUT_CODE)
+            endpoint = "checkout";
+        else if (errorEndpoint == ErrorMessage.EXECUTE_ORDER_CODE)
+            endpoint = "execute";
+        else
+            endpoint = "payment";
+        body.append(String.format("%s: %s", activity.getString(R.string.label_error), endpoint));
+        body.append(String.format(Locale.ENGLISH, "-%d", errorCode));
+
+        if (errorMessage != null && !errorMessage.isEmpty())
+            body.append(String.format("-%s", errorMessage));
+        body.append(NEW_LINE);
+        return body;
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.kt
@@ -254,15 +254,17 @@ class CourseUnitMobileNotSupportedFragment : CourseUnitFragment() {
         @StringRes errorResId: Int = R.string.general_error_message,
         feedbackErrorCode: Int? = null,
         feedbackErrorMessage: String? = null,
-        feedbackEndpoint: Int? = null
+        feedbackEndpoint: Int? = null,
+        listener: DialogInterface.OnClickListener? = null
     ) {
         AlertDialogFragment.newInstance(
             getString(R.string.title_upgrade_error),
             getString(errorResId),
-            getString(R.string.label_close),
-            null,
-            getString(R.string.label_get_help)
+            getString(if (listener != null) R.string.try_again else R.string.label_close),
+            listener,
+            getString(if (listener != null) R.string.label_cancel else R.string.label_get_help)
         ) { _, _ ->
+            listener?.let { return@newInstance }
             environment.router?.showFeedbackScreen(
                 requireActivity(),
                 getString(R.string.email_subject_upgrade_error),
@@ -271,20 +273,6 @@ class CourseUnitMobileNotSupportedFragment : CourseUnitFragment() {
                 feedbackErrorMessage
             )
         }.show(childFragmentManager, null)
-    }
-
-    private fun showUpgradeErrorDialog(
-        @StringRes errorResId: Int = R.string.general_error_message,
-        listener: DialogInterface.OnClickListener
-    ) {
-        AlertDialogFragment.newInstance(
-            getString(R.string.title_upgrade_error),
-            getString(errorResId),
-            getString(R.string.try_again),
-            listener,
-            getString(R.string.label_cancel),
-            null
-        ).show(childFragmentManager, null)
     }
 
     private fun showPurchaseSuccessSnackbar() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
-import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -23,7 +22,6 @@ import org.edx.mobile.deeplink.ScreenDef;
 import org.edx.mobile.discussion.DiscussionComment;
 import org.edx.mobile.discussion.DiscussionThread;
 import org.edx.mobile.discussion.DiscussionTopic;
-import org.edx.mobile.exception.ErrorMessage;
 import org.edx.mobile.model.api.CourseUpgradeResponse;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.model.course.CourseComponent;
@@ -36,11 +34,10 @@ import org.edx.mobile.util.Config;
 import org.edx.mobile.util.EmailUtil;
 import org.edx.mobile.util.ResourceUtil;
 import org.edx.mobile.util.SecurityUtil;
+import org.edx.mobile.util.TextUtils;
 import org.edx.mobile.util.links.WebViewLink;
 import org.edx.mobile.view.dialog.WebViewActivity;
 import org.edx.mobile.whatsnew.WhatsNewActivity;
-
-import java.util.Locale;
 
 import javax.inject.Inject;
 
@@ -162,7 +159,7 @@ public class Router {
     public void showMainDashboard(@NonNull Activity sourceActivity, @Nullable @ScreenDef String screenName,
                                   @Nullable String pathId) {
         Intent intent = MainDashboardActivity.newIntent(screenName, pathId);
-        if (!TextUtils.isEmpty(screenName)) {
+        if (!android.text.TextUtils.isEmpty(screenName)) {
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         }
         sourceActivity.startActivity(intent);
@@ -527,34 +524,9 @@ public class Router {
                 .append(NEW_LINE)
                 .append(String.format("%s %s", activity.getString(R.string.android_device_model), Build.MODEL))
                 .append(NEW_LINE)
-                .append(getFormattedErrorMessage(activity, errorCode, errorEndpoint, errorMessage))
+                .append(TextUtils.getFormattedErrorMessage(activity, errorCode, errorEndpoint, errorMessage))
                 .append(NEW_LINE)
                 .append(activity.getString(R.string.insert_feedback));
         EmailUtil.openEmailClient(activity, to, subject, body.toString(), config);
-    }
-
-    private StringBuilder getFormattedErrorMessage(
-            @NonNull FragmentActivity activity,
-            Integer errorCode,
-            Integer errorEndpoint,
-            String errorMessage) {
-        final String NEW_LINE = "\n";
-        StringBuilder body = new StringBuilder();
-        if (errorEndpoint == null || errorCode == null) return body;
-        String endpoint;
-        if (errorEndpoint == ErrorMessage.ADD_TO_BASKET_CODE)
-            endpoint = "basket";
-        else if (errorEndpoint == ErrorMessage.CHECKOUT_CODE)
-            endpoint = "checkout";
-        else if (errorEndpoint == ErrorMessage.EXECUTE_ORDER_CODE)
-            endpoint = "execute";
-        else
-            endpoint = "payment";
-        body.append(String.format("%s: %s", activity.getString(R.string.label_error), endpoint));
-        body.append(String.format(Locale.ENGLISH, "-%d", errorCode));
-        if (errorMessage != null && !errorMessage.isEmpty())
-            body.append(String.format("-%s", errorMessage));
-        body.append(NEW_LINE);
-        return body;
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
@@ -240,36 +240,26 @@ class CourseModalDialogFragment : DialogFragment() {
         @StringRes errorResId: Int = R.string.general_error_message,
         feedbackErrorCode: Int? = null,
         feedbackErrorMessage: String? = null,
-        feedbackEndpoint: Int? = null
+        feedbackEndpoint: Int? = null,
+        listener: DialogInterface.OnClickListener? = null
     ) {
         AlertDialogFragment.newInstance(
             getString(R.string.title_upgrade_error),
             getString(errorResId),
-            getString(R.string.label_close),
-            null,
-            getString(R.string.label_get_help)
-        ) { _, _ ->
-            environment.router?.showFeedbackScreen(
-                requireActivity(),
-                getString(R.string.email_subject_upgrade_error),
-                feedbackErrorCode,
-                feedbackEndpoint,
-                feedbackErrorMessage
-            )
-        }.show(childFragmentManager, null)
-    }
-
-    private fun showUpgradeErrorDialog(
-        @StringRes errorResId: Int = R.string.general_error_message,
-        listener: DialogInterface.OnClickListener
-    ) {
-        AlertDialogFragment.newInstance(
-            getString(R.string.title_upgrade_error),
-            getString(errorResId),
-            getString(R.string.try_again),
+            getString(if (listener != null) R.string.try_again else R.string.label_close),
             listener,
-            getString(R.string.label_cancel),
-        ) { _, _ -> dismiss() }.show(childFragmentManager, null)
+            getString(if (listener != null) R.string.label_cancel else R.string.label_get_help)
+        ) { _, _ ->
+            listener?.let { dismiss() } ?: run {
+                environment.router?.showFeedbackScreen(
+                    requireActivity(),
+                    getString(R.string.email_subject_upgrade_error),
+                    feedbackErrorCode,
+                    feedbackEndpoint,
+                    feedbackErrorMessage
+                )
+            }
+        }.show(childFragmentManager, null)
     }
 
     private fun showPurchaseSuccessSnackbar() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/InAppPurchasesViewModel.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/InAppPurchasesViewModel.kt
@@ -23,8 +23,8 @@ class InAppPurchasesViewModel @Inject constructor(
     private val _showLoader = MutableLiveData<Boolean>()
     val showLoader: LiveData<Boolean> = _showLoader
 
-    private val _errorMessage = MutableLiveData<ErrorMessage>()
-    val errorMessage: LiveData<ErrorMessage> = _errorMessage
+    private val _errorMessage = MutableLiveData<ErrorMessage?>()
+    val errorMessage: LiveData<ErrorMessage?> = _errorMessage
 
     private val _checkoutResponse = MutableLiveData<CheckoutResponse>()
     val checkoutResponse: LiveData<CheckoutResponse> = _checkoutResponse


### PR DESCRIPTION
### Description

[LEARNER-8759](https://openedx.atlassian.net/browse/LEARNER-8759)

[Error Mapping](https://openedx.atlassian.net/wiki/spaces/LEARNER/pages/3354624046/In-App+Purchases+Error+Mapping) finalized in this ticket: [LEARNER-8758](https://openedx.atlassian.net/browse/LEARNER-8758)

According to the Figma file, it’s intended to send only the error code in the support email, but we are getting the same error codes in different cases like `400: {'error': 'Basket [basket id] not found'`} and `400: {'error': 'Payment processor [payment processor] not found'}` getting 400 in two different cases. So the team decides to send more information in the error field of the email. The team decides to send the details like `Error: error_location(basket/checkout/payment/etc)-error_code-error_message` 

**Examples:**
Error: basket-406-You have already purchased this course.
Error: payment-2
