### PR TITLE
fix: Add verification before using SegmentAnalytics

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/SegmentAnalytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/SegmentAnalytics.java
@@ -47,6 +47,8 @@ public class SegmentAnalytics implements Analytics {
 
     @Inject
     public SegmentAnalytics(@ApplicationContext @NonNull Context context, @NonNull Config config) {
+        if (!config.getSegmentConfig().isEnabled()) return;
+
         final String writeKey = config.getSegmentConfig().getSegmentWriteKey();
         final boolean debugging = context.getResources().getBoolean(R.bool.analytics_debug);
         final int queueSize = context.getResources().getInteger(R.integer.analytics_queue_size);


### PR DESCRIPTION
### Description
I was trying to run the app without the analytics configuration, but the app crashes without this configuration.
I just added a verification before this block of code because our team doesn't use the Analytics Segment
### Notes
Please provide feedback so I can improve is necessary this verification.

### Testing
- [x] Analytics
