### PR TITLE
fix: LoginAPI correctly injected on RegisterTask

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/task/RegisterTask.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/task/RegisterTask.java
@@ -5,25 +5,25 @@ import android.os.Bundle;
 
 import org.edx.mobile.authentication.AuthResponse;
 import org.edx.mobile.authentication.LoginAPI;
+import org.edx.mobile.core.EdxDefaultModule;
 import org.edx.mobile.social.SocialFactory;
 
-import javax.inject.Inject;
-
+import dagger.hilt.android.EntryPointAccessors;
 
 public abstract class RegisterTask extends Task<AuthResponse> {
 
     private Bundle parameters;
     private SocialFactory.SOCIAL_SOURCE_TYPE backstoreType;
     private String accessToken;
-
-    @Inject
-    LoginAPI loginAPI;
+    private LoginAPI loginAPI;
 
     public RegisterTask(Context context, Bundle parameters, String accessToken, SocialFactory.SOCIAL_SOURCE_TYPE backstoreType) {
         super(context);
         this.parameters = parameters;
         this.accessToken = accessToken;
         this.backstoreType = backstoreType;
+        loginAPI = EntryPointAccessors.fromApplication(
+                context, EdxDefaultModule.ProviderEntryPoint.class).getLoginAPI();
     }
 
     @Override

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
@@ -344,8 +344,10 @@ public class RegisterActivity extends BaseFragmentActivity
             @Override
             protected void onPostExecute(AuthResponse auth) {
                 super.onPostExecute(auth);
-                environment.getAnalyticsRegistry().trackRegistrationSuccess(appVersion, provider);
-                onUserLoginSuccess(auth.profile);
+                if (auth != null) {
+                    environment.getAnalyticsRegistry().trackRegistrationSuccess(appVersion, provider);
+                    onUserLoginSuccess(auth.profile);
+                }
             }
 
             @Override

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/NativeFindCoursesFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/NativeFindCoursesFragment.java
@@ -24,8 +24,10 @@ import org.edx.mobile.view.common.TaskMessageCallback;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
 import retrofit2.Call;
 
+@AndroidEntryPoint
 public class NativeFindCoursesFragment extends BaseFragment {
 
     @Inject


### PR DESCRIPTION
### Description

- The LoginAPI on RegisterTask was not being successfully injected.
- The CourseAPI on NativeFindCoursesFragment was not being successfully injected.
- Also, when the Open edX instance makes use of REGISTRATION_EMAIL_PATTERNS_ALLOWED setting, and the user enters an unauthorized email the RegisterActivity was closed after show the error message. After some debugging, I see that the RegisterTask.onException method was successfully called on the LoginAPI.RegistrationException event on the RegisterTask.doInBackground but the RegisterTask.onPostExecute was called with a null AuthResponse object. I added a verification before the calling of the RegisterActivity.onUserLoginSuccess method.
### Notes
Please provide any feedback that will be useful to improve this code