### PR TITLE
feat: Add retry option for failed IAP verification or refresh call

### DIFF
--- a/OpenEdXMobile/res/values/iap_strings.xml
+++ b/OpenEdXMobile/res/values/iap_strings.xml
@@ -18,6 +18,8 @@
     <string name="email_subject_upgrade_error">Error upgrading course in app</string>
     <!-- Get Help button label -->
     <string name="label_get_help">Get Help</string>
+    <!-- Refresh To Retry button label -->
+    <string name="label_refresh_to_retry">Refresh to retry</string>
 
     <!--  Error Messages  -->
     <!--  Course didn't found against the course sku in the course upgrade API -->

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseAPI.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseAPI.java
@@ -103,7 +103,15 @@ public class CourseAPI {
      */
     @NonNull
     public Call<List<EnrolledCoursesResponse>> getEnrolledCourses() {
-        return courseService.getEnrolledCourses(getUsername(), config.getOrganizationCode());
+        return courseService.getEnrolledCourses(null, getUsername(), config.getOrganizationCode());
+    }
+
+    /**
+     * @return Enrolled courses of given user without stale response.
+     */
+    @NonNull
+    public Call<List<EnrolledCoursesResponse>> getEnrolledCoursesWithoutStale() {
+        return courseService.getEnrolledCourses("stale-if-error=0", getUsername(), config.getOrganizationCode());
     }
 
     /**
@@ -217,7 +225,7 @@ public class CourseAPI {
 
     @NonNull
     public Call<CourseStructureV1Model> getCourseStructureWithoutStale(@NonNull String blocksApiVersion, @NonNull String courseId) {
-        return courseService.getCourseStructure(null, blocksApiVersion, getUsername(), courseId);
+        return courseService.getCourseStructure("stale-if-error=0", blocksApiVersion, getUsername(), courseId);
     }
 
     @NonNull

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseService.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseService.java
@@ -103,8 +103,10 @@ public interface CourseService {
      * @return Enrolled courses of given user.
      */
     @GET("/api/mobile/v1/users/{username}/course_enrollments")
-    Call<List<EnrolledCoursesResponse>> getEnrolledCourses(@Path("username") final String username,
-                                                           @Query("org") final String org);
+    Call<List<EnrolledCoursesResponse>> getEnrolledCourses(
+            @Header("Cache-Control") String cacheControlHeaderParam,
+            @Path("username") final String username,
+            @Query("org") final String org);
 
     /**
      * @return Enrolled courses of given user, only from the cache.

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/exception/ErrorMessage.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/exception/ErrorMessage.kt
@@ -21,5 +21,6 @@ data class ErrorMessage(
         const val CHECKOUT_CODE = 0x202
         const val EXECUTE_ORDER_CODE = 0x203
         const val PAYMENT_SDK_CODE = 0x204
+        const val COURSE_REFRESH_CODE = 0x205
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
@@ -56,6 +56,8 @@ public abstract class CourseBaseActivity extends BaseFragmentActivity
 
     protected abstract void onLoadData();
 
+    protected abstract void onCourseRefreshError(Throwable error);
+
     private FullScreenErrorNotification errorNotification;
 
     @Override
@@ -132,6 +134,12 @@ public abstract class CourseBaseActivity extends BaseFragmentActivity
                 }
                 invalidateOptionsMenu();
                 onLoadData();
+            }
+
+            @Override
+            protected void onFailure(@NonNull Throwable error) {
+                super.onFailure(error);
+                onCourseRefreshError(error);
             }
         });
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
@@ -27,6 +27,7 @@ import org.edx.mobile.databinding.ViewCourseUnitPagerBinding;
 import org.edx.mobile.event.CourseUpgradedEvent;
 import org.edx.mobile.event.FileSelectionEvent;
 import org.edx.mobile.event.VideoPlaybackEvent;
+import org.edx.mobile.exception.ErrorMessage;
 import org.edx.mobile.http.callback.ErrorHandlingCallback;
 import org.edx.mobile.http.notifications.SnackbarErrorNotification;
 import org.edx.mobile.logger.Logger;
@@ -262,6 +263,13 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
     protected void onLoadData() {
         selectedUnit = courseManager.getComponentById(blocksApiVersion, courseData.getCourse().getId(), courseComponentId);
         updateDataModel();
+    }
+
+    @Override
+    protected void onCourseRefreshError(Throwable error) {
+        if (fullScreenLoader != null && fullScreenLoader.isAdded()) {
+            iapViewModel.setError(ErrorMessage.COURSE_REFRESH_CODE, error);
+        }
     }
 
     private void setCurrentUnit(CourseComponent component) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.kt
@@ -175,7 +175,8 @@ class MyCoursesListFragment : OfflineSupportBaseFragment(), RefreshListener {
             NonNullObserver { refreshCourse ->
                 if (refreshCourse) {
                     refreshOnPurchase = true
-                    loadData(showProgress = false, fromCache = false)
+                    enrolledCoursesCall = courseAPI.enrolledCoursesWithoutStale
+                    getUserEnrolledCourses(false)
                     iapViewModel.refreshCourseData(false)
                 }
             })
@@ -298,7 +299,7 @@ class MyCoursesListFragment : OfflineSupportBaseFragment(), RefreshListener {
                     call.isCanceled -> logger.error(t)
                     fromCache -> loadData(showProgress = true, fromCache = false)
                     (fullscreenLoader?.isAdded == true) -> iapViewModel.setError(
-                        ErrorMessage.EXECUTE_ORDER_CODE,
+                        ErrorMessage.COURSE_REFRESH_CODE,
                         t
                     )
                     else -> {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/AlertDialogFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/AlertDialogFragment.java
@@ -32,6 +32,8 @@ public class AlertDialogFragment extends DialogFragment {
     protected ButtonAttribute positiveButtonAttr;
     @Nullable
     protected ButtonAttribute negativeButtonAttr;
+    @Nullable
+    protected ButtonAttribute neutralButtonAttr;
 
     /**
      * Creates a new instance of simple dialog that shows message, could have title and will have
@@ -169,6 +171,79 @@ public class AlertDialogFragment extends DialogFragment {
     }
 
     /**
+     * Creates a new instance of dialog that shows message, could have title, will have a positive,
+     * negative and neutral button with given text.
+     *
+     * @param title           Title of dialog.
+     * @param message         Message of dialog.
+     * @param positiveText    Positive button text.
+     * @param onPositiveClick Positive button click listener.
+     * @param negativeText    Negative button text.
+     * @param onNegativeClick Negative button click listener.
+     * @param neutralText     Neutral button text.
+     * @param onNeutralClick  Neutral button click listener.
+     * @param isCancelable    Flag to set dialog cancelable.
+     * @return New instance of dialog.
+     */
+    public static AlertDialogFragment newInstance(final @Nullable String title,
+                                                  final @NonNull String message,
+                                                  final @NonNull String positiveText,
+                                                  final @Nullable DialogInterface.OnClickListener onPositiveClick,
+                                                  final @Nullable String negativeText,
+                                                  final @Nullable DialogInterface.OnClickListener onNegativeClick,
+                                                  final @Nullable String neutralText,
+                                                  final @Nullable DialogInterface.OnClickListener onNeutralClick,
+                                                  final boolean isCancelable) {
+        final AlertDialogFragment fragment = new AlertDialogFragment();
+        // Supply params as an argument.
+        final Bundle arguments = new Bundle();
+        arguments.putString(ARG_TITLE, title);
+        arguments.putString(ARG_MESSAGE, message);
+        fragment.positiveButtonAttr = new ButtonAttribute() {
+            @NonNull
+            @Override
+            public String getText() {
+                return positiveText;
+            }
+
+            @Nullable
+            @Override
+            public DialogInterface.OnClickListener getOnClickListener() {
+                return onPositiveClick;
+            }
+        };
+        fragment.negativeButtonAttr = new ButtonAttribute() {
+            @NonNull
+            @Override
+            public String getText() {
+                return negativeText;
+            }
+
+            @Nullable
+            @Override
+            public DialogInterface.OnClickListener getOnClickListener() {
+                return onNegativeClick;
+            }
+        };
+        fragment.neutralButtonAttr = new ButtonAttribute() {
+            @Nullable
+            @Override
+            String getText() {
+                return neutralText;
+            }
+
+            @Nullable
+            @Override
+            DialogInterface.OnClickListener getOnClickListener() {
+                return onNeutralClick;
+            }
+        };
+        arguments.putBoolean(ARG_IS_CANCELABLE, isCancelable);
+        fragment.setArguments(arguments);
+        return fragment;
+    }
+
+    /**
      * Creates a new instance of simple custom layout dialog that could have title and layout Id
      *
      * @param titleResId  Resource Id of title
@@ -226,6 +301,10 @@ public class AlertDialogFragment extends DialogFragment {
             alertDialog.setButton(DialogInterface.BUTTON_NEGATIVE, negativeButtonAttr.getText(),
                     negativeButtonAttr.getOnClickListener());
         }
+        if (neutralButtonAttr != null) {
+            alertDialog.setButton(DialogInterface.BUTTON_NEUTRAL, neutralButtonAttr.getText(),
+                    neutralButtonAttr.getOnClickListener());
+        }
 
         alertDialog.setOnShowListener(dialog -> {
             if (positiveButtonAttr != null) {
@@ -238,8 +317,13 @@ public class AlertDialogFragment extends DialogFragment {
                 negativeButton.setTextColor(getContext().getResources().getColor(R.color.primaryBaseColor));
                 negativeButton.setTypeface(null, Typeface.BOLD);
             }
+            if (neutralButtonAttr != null) {
+                Button neutralButton = alertDialog.getButton(DialogInterface.BUTTON_NEUTRAL);
+                neutralButton.setTextColor(getContext().getResources().getColor(R.color.primaryBaseColor));
+                neutralButton.setTypeface(null, Typeface.BOLD);
+            }
         });
-        final boolean isCancelable = args.getBoolean(ARG_IS_CANCELABLE, false);
+        final boolean isCancelable = args.getBoolean(ARG_IS_CANCELABLE, true);
         alertDialog.setCancelable(isCancelable);
         return alertDialog;
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
@@ -238,24 +238,25 @@ class CourseModalDialogFragment : DialogFragment() {
         listener: DialogInterface.OnClickListener? = null
     ) {
         // To restrict showing error dialog on an unattached fragment
-        if (!isAdded) return;
+        if (!isAdded) return
         AlertDialogFragment.newInstance(
             getString(R.string.title_upgrade_error),
             getString(errorResId),
             getString(if (listener != null) R.string.try_again else R.string.label_close),
             listener,
-            getString(if (listener != null) R.string.label_cancel else R.string.label_get_help)
-        ) { _, _ ->
-            listener?.let { dismiss() } ?: run {
-                environment.router?.showFeedbackScreen(
-                    requireActivity(),
-                    getString(R.string.email_subject_upgrade_error),
-                    feedbackErrorCode,
-                    feedbackEndpoint,
-                    feedbackErrorMessage
-                )
-            }
-        }.show(childFragmentManager, null)
+            getString(if (listener != null) R.string.label_cancel else R.string.label_get_help),
+            { _, _ ->
+                listener?.let { dismiss() } ?: run {
+                    environment.router?.showFeedbackScreen(
+                        requireActivity(),
+                        getString(R.string.email_subject_upgrade_error),
+                        feedbackErrorCode,
+                        feedbackEndpoint,
+                        feedbackErrorMessage
+                    )
+                }
+            }, false
+        ).show(childFragmentManager, null)
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
### Description

[LEARNER-8813](https://openedx.atlassian.net/browse/LEARNER-8813)

Give an option of Retry to the learner as per the [figma](https://www.figma.com/file/SFpqDv2FVf2RRV56ATEakH/Payments?node-id=3061%3A4177) to update the content if the failure occurs after the payment. This can happen in the following cases:
- execute API failed to verify the payment and update the course mode to verified.

- execute API successfully verified the payment and updated the course mode to verified but blocks API fails to get the updated data course data from the server.

![Screenshot_2022-04-22-07-59-21-160_org edx mobile](https://user-images.githubusercontent.com/71447999/164587758-59bed092-22b9-43b9-a0b9-9b3ce64f3743.jpg)

### Notes
- Calls enrollment and blocks API without stale so we can get the upgraded content directly from the server

### Test the failure and success case:
Execute API
- [ ] MyCourseList screen with and without internet
- [ ] Course Dashboard screen with and without internet

Blocks API
- [ ] MyCourseList screen with and without internet
- [ ] Course Dashboard screen with and without internet
