### PR TITLE
fix: Hide value prop for archived courses only

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseCardViewHolder.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseCardViewHolder.java
@@ -70,8 +70,7 @@ public class CourseCardViewHolder extends BaseListAdapter.BaseViewHolder {
     }
 
     public void setHasUpgradeOption(@NonNull CourseEntry courseData, String mode, View.OnClickListener onValuePropClick) {
-        if (!courseData.isEnded() && courseData.getDynamicUpgradeDeadline() != null &&
-                mode.equalsIgnoreCase(EnrollmentMode.AUDIT.toString())) {
+        if (!courseData.isEnded() && mode.equalsIgnoreCase(EnrollmentMode.AUDIT.toString())) {
             propContainer.setVisibility(View.VISIBLE);
             propContainer.setOnClickListener(onValuePropClick);
         } else {


### PR DESCRIPTION
### Description

[LEARNER-8875](https://2u-internal.atlassian.net/browse/LEARNER-8875)

The `dynamic_upgrade_deadline` flag was wrongly used to hide value prop on MyCourseListFragment.