### PR TITLE
feat: Handle unfulfilled and externally-fulfilled IAPs

### DIFF
--- a/OpenEdXMobile/res/values/iap_strings.xml
+++ b/OpenEdXMobile/res/values/iap_strings.xml
@@ -27,7 +27,7 @@
     <!-- Authentication error in course upgrade API's basket, checkout, execute  -->
     <string name="error_user_not_authenticated">Your account could not be authenticated. Try signing out and signing back into the app. If this error continues, please contact Support.</string>
     <!--  The course is already upgraded  -->
-    <string name="error_course_already_paid">The course you are looking to upgrade has already been paid for. For additional help, reach out to Support.</string>
+    <string name="error_course_already_paid">The course you are looking to upgrade has already been paid for. To update, we need to quickly refresh your app.</string>
     <!--  Course sku or the payment processor didn't found  -->
     <string name="error_payment_not_processed">Your payment could not be processed at this time. Please try again. For additional help, reach out to Support.</string>
     <!--  The native payment is complete but an error occurred while marking the course verified  -->
@@ -42,4 +42,14 @@
 
     <!-- Label Course Modal Unlock Graded Assignments -->
     <string name="course_modal_unlock_graded_assignment">Unlock graded assignments</string>
+
+    <!-- Silent Course Upgrade Success Alert -->
+    <!-- Silent Course Upgrade Success Alert Title -->
+    <string name="silent_course_upgrade_success_title">New experience available</string>
+    <!-- Silent Course Upgrade Success Alert Message -->
+    <string name="silent_course_upgrade_success_message">An update is available to unlock a purchased course. To update, we need to quickly refresh your app. If you choose not to update now, we’ll try again later.</string>
+    <!-- Label Refresh Now -->
+    <string name="label_refresh_now">Refresh now</string>
+    <!-- Label Continue Without Update -->
+    <string name="label_continue_without_update">Continue without update</string>
 </resources>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/EncryptionExt.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/EncryptionExt.kt
@@ -1,0 +1,15 @@
+package org.edx.mobile.extenstion
+
+import android.util.Base64
+
+fun Long.encodeToString(): String {
+    return Base64.encodeToString(this.toString().toByteArray(), Base64.DEFAULT)
+}
+
+fun String.decodeToLong(): Long? {
+    return try {
+        Base64.decode(this, Base64.DEFAULT).toString(Charsets.UTF_8).toLong()
+    } catch (ex: Exception) {
+        null
+    }
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/HttpStatusException.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/HttpStatusException.java
@@ -2,7 +2,9 @@ package org.edx.mobile.http;
 
 import androidx.annotation.NonNull;
 
+import okhttp3.MediaType;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 
 /**
  * Signals an HTTP status error.
@@ -29,6 +31,29 @@ public class HttpStatusException extends Exception {
      */
     public HttpStatusException(@NonNull final retrofit2.Response<?> response) {
         this(response.raw());
+    }
+
+    /**
+     * Constructs a new {@code HttpResponseStatusException}.
+     *
+     * @param code    The Retrofit error response code.
+     * @param content The Retrofit error response message
+     */
+    public HttpStatusException(int code, String content) {
+        this(retrofit2.Response.error(code,
+                ResponseBody.create(content, MediaType.parse("text/plain"))).raw());
+    }
+
+    /**
+     * Constructs a new {@code HttpResponseStatusException}.
+     *
+     * @param code        The Retrofit error response code.
+     * @param content     The Retrofit error response message
+     * @param contentType The Retrofit error response MediaType
+     */
+    public HttpStatusException(int code, String content, String contentType) {
+        this(retrofit2.Response.error(code,
+                ResponseBody.create(content, MediaType.parse(contentType))).raw());
     }
 
     /**

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/EnrolledCoursesResponse.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/EnrolledCoursesResponse.java
@@ -123,7 +123,7 @@ public class EnrolledCoursesResponse implements SectionItemInterface {
         isDiscussionBlackedOut = discussionBlackedOut;
     }
 
-    public String getProductSku() {
+    public String getCourseSku() {
         if (courseModes == null || courseModes.size() == 0) {
             return null;
         } else {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/CourseComponent.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/CourseComponent.java
@@ -42,7 +42,7 @@ public class CourseComponent implements IBlock, IPathNode {
     private String authorizationDenialMessage;
     private AuthorizationDenialReason authorizationDenialReason;
     private SpecialExamInfo specialExamInfo;
-    private String productSku;
+    private String courseSku;
 
     public CourseComponent() {
     }
@@ -68,7 +68,7 @@ public class CourseComponent implements IBlock, IPathNode {
         this.authorizationDenialMessage = other.authorizationDenialMessage;
         this.authorizationDenialReason = other.authorizationDenialReason;
         this.specialExamInfo = other.specialExamInfo;
-        this.productSku = other.productSku;
+        this.courseSku = other.courseSku;
     }
 
     /**
@@ -560,11 +560,11 @@ public class CourseComponent implements IBlock, IPathNode {
         return specialExamInfo;
     }
 
-    public String getProductSku() {
-        return productSku;
+    public String getCourseSku() {
+        return courseSku;
     }
 
-    public void setProductSku(String productSku) {
-        this.productSku = productSku;
+    public void setCourseSku(String courseSku) {
+        this.courseSku = courseSku;
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
@@ -164,6 +164,12 @@ public class LoginPrefs {
     }
 
     @Nullable
+    public Long getUserId() {
+        final ProfileModel profileModel = getCurrentUserProfile();
+        return profileModel != null ? profileModel.id : null;
+    }
+
+    @Nullable
     public String getUsername() {
         final ProfileModel profileModel = getCurrentUserProfile();
         return null == profileModel ? null : profileModel.username;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/InAppPurchasesUtils.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/InAppPurchasesUtils.kt
@@ -1,0 +1,196 @@
+package org.edx.mobile.util
+
+import android.content.DialogInterface
+import androidx.annotation.StringRes
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.Fragment
+import org.edx.mobile.R
+import org.edx.mobile.core.IEdxEnvironment
+import org.edx.mobile.exception.ErrorMessage
+import org.edx.mobile.http.HttpStatus
+import org.edx.mobile.module.analytics.Analytics.Events
+import org.edx.mobile.module.analytics.Analytics.Values
+import org.edx.mobile.module.analytics.InAppPurchasesAnalytics
+import org.edx.mobile.view.dialog.AlertDialogFragment
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class InAppPurchasesUtils @Inject constructor(
+    var environment: IEdxEnvironment,
+    var iapAnalytics: InAppPurchasesAnalytics,
+) {
+
+    /**
+     * Shows Alert Dialog for all error cases that can occur before a successful course purchase i.e
+     * SKU/Product ID not available (Enrollment-API), while fetching the price from Play Console
+     * (Payment SDK), Adding course in purchase basket/cart (Basket-API), during basket checkout
+     * (Checkout-API) or while purchasing a course (Payment SDK).
+     *
+     * All Alerts (except Price Fetching): Two buttons; Cancel and Get help, without any listener
+     * Fetching Price Alert: Two buttons; Try again & Cancel, with a listener for Try again
+     *
+     * Events are also tracked on interaction with the alert.
+     *
+     * @param context Fragment context for resolving message strings and displaying the dialog
+     * @param errorResId Reference to the localized string resource for message
+     * @param errorCode Http Status Code for feedback message
+     * @param errorMessage API error response for feedback message
+     * @param errorType IAP [ErrorMessage] type/code for feedback message
+     * @param listener Retry listener to fetch the course price again
+     */
+    fun showUpgradeErrorDialog(
+        context: Fragment,
+        @StringRes errorResId: Int = R.string.general_error_message,
+        errorCode: Int? = null,
+        errorMessage: String? = null,
+        errorType: Int? = null,
+        listener: DialogInterface.OnClickListener? = null
+    ) {
+        // To restrict showing error dialog on an unattached fragment
+        if (!context.isAdded) return
+
+        val feedbackErrorMessage: String = TextUtils.getFormattedErrorMessage(
+            errorCode,
+            errorType,
+            errorMessage
+        ).toString()
+
+        when (errorType) {
+            ErrorMessage.PAYMENT_SDK_CODE -> iapAnalytics.trackIAPEvent(
+                eventName = Events.IAP_PAYMENT_ERROR,
+                errorMsg = feedbackErrorMessage
+            )
+            ErrorMessage.PRICE_CODE -> iapAnalytics.trackIAPEvent(
+                eventName = Events.IAP_PRICE_LOAD_ERROR,
+                errorMsg = feedbackErrorMessage
+            )
+            else -> iapAnalytics.trackIAPEvent(
+                eventName = Events.IAP_COURSE_UPGRADE_ERROR,
+                errorMsg = feedbackErrorMessage
+            )
+        }
+
+        AlertDialogFragment.newInstance(
+            context.getString(R.string.title_upgrade_error),
+            context.getString(errorResId),
+            context.getString(if (listener != null) R.string.try_again else R.string.label_close),
+            { dialog, which ->
+                listener?.onClick(dialog, which).also {
+                    iapAnalytics.trackIAPEvent(
+                        eventName = Events.IAP_ERROR_ALERT_ACTION,
+                        errorMsg = feedbackErrorMessage,
+                        actionTaken = Values.ACTION_RELOAD_PRICE
+                    )
+                } ?: run { trackAlertCloseEvent(feedbackErrorMessage) }
+            },
+            context.getString(if (listener != null) R.string.label_cancel else R.string.label_get_help),
+            { _, _ ->
+                if (listener != null) {
+                    trackAlertCloseEvent(feedbackErrorMessage)
+                    if (context is DialogFragment) context.dismiss()
+                } else {
+                    showFeedbackScreen(context, feedbackErrorMessage)
+                }
+            }, false
+        ).show(context.childFragmentManager, null)
+    }
+
+    /**
+     * Shows Alert Dialog for all error cases that can occur after a successful course purchase i.e
+     * Course already purchased (Basket-API) or unable to verify the purchase on backend
+     * (Execute-API).
+     *
+     * Course Already Purchased : Three buttons; Refresh Now, Get help and Cancel, with two
+     * listeners. One for refresh and the other one for Get help and Cancel
+     * Unable to Verify: Three buttons; Refresh to retry, Get help and Cancel, with two listeners.
+     * One for Refresh to retry and the other one for Get Help and Cancel
+     *
+     * Events are also tracked on interaction with the alert.
+     *
+     * @param context Fragment context for resolving message strings and displaying the dialog
+     * @param errorResId Reference to the localized string resource for message
+     * @param errorCode Http Status Code for feedback message
+     * @param errorMessage API error response for feedback message
+     * @param errorType IAP [ErrorMessage] type/code for feedback message
+     * @param retryListener Retry listener to fetch the upgraded course again or to verify the
+     * purchase
+     * @param cancelListener Cancel listener to reset the purchase flow
+     */
+    fun showPostUpgradeErrorDialog(
+        context: Fragment,
+        @StringRes errorResId: Int = R.string.error_course_not_fullfilled,
+        errorCode: Int? = null,
+        errorMessage: String? = null,
+        errorType: Int? = null,
+        retryListener: DialogInterface.OnClickListener? = null,
+        cancelListener: DialogInterface.OnClickListener? = null
+    ) {
+
+        val feedbackErrorMessage: String = TextUtils.getFormattedErrorMessage(
+            errorCode,
+            errorType,
+            errorMessage
+        ).toString()
+
+        iapAnalytics.trackIAPEvent(
+            eventName = Events.IAP_COURSE_UPGRADE_ERROR,
+            errorMsg = feedbackErrorMessage
+        )
+        AlertDialogFragment.newInstance(
+            context.getString(R.string.title_upgrade_error),
+            context.getString(errorResId),
+            context.getString(
+                if (errorCode == HttpStatus.NOT_ACCEPTABLE) R.string.label_refresh_now
+                else R.string.label_refresh_to_retry
+            ),
+            { dialog, which ->
+                retryListener?.onClick(dialog, which).also {
+                    if (errorCode == HttpStatus.NOT_ACCEPTABLE) {
+                        // Add Analytics for refresh course on unfulfilled payments
+                    } else {
+                        iapAnalytics.initRefreshContentTime()
+                        iapAnalytics.trackIAPEvent(
+                            eventName = Events.IAP_ERROR_ALERT_ACTION,
+                            errorMsg = feedbackErrorMessage,
+                            actionTaken = Values.ACTION_REFRESH
+                        )
+                    }
+                }
+            },
+            context.getString(R.string.label_get_help),
+            { dialog, which ->
+                cancelListener?.onClick(dialog, which).also {
+                    showFeedbackScreen(context, feedbackErrorMessage)
+                }
+            },
+            context.getString(R.string.label_cancel),
+            { dialog, which ->
+                cancelListener?.onClick(dialog, which).also {
+                    trackAlertCloseEvent(feedbackErrorMessage)
+                }
+            }, false
+        ).show(context.childFragmentManager, null)
+    }
+
+    private fun trackAlertCloseEvent(feedbackErrorMessage: String) {
+        iapAnalytics.trackIAPEvent(
+            eventName = Events.IAP_ERROR_ALERT_ACTION,
+            errorMsg = feedbackErrorMessage,
+            actionTaken = Values.ACTION_CLOSE
+        )
+    }
+
+    private fun showFeedbackScreen(context: Fragment, feedbackErrorMessage: String) {
+        environment.router?.showFeedbackScreen(
+            context.requireActivity(),
+            context.getString(R.string.email_subject_upgrade_error),
+            feedbackErrorMessage
+        )
+        iapAnalytics.trackIAPEvent(
+            eventName = Events.IAP_ERROR_ALERT_ACTION,
+            errorMsg = feedbackErrorMessage,
+            actionTaken = Values.ACTION_GET_HELP
+        )
+    }
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/WebViewUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/WebViewUtil.java
@@ -2,11 +2,12 @@ package org.edx.mobile.util;
 
 import android.content.Context;
 import android.os.Build;
+import android.view.View;
+import android.webkit.WebView;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
-import android.view.View;
-import android.webkit.WebView;
 
 import org.edx.mobile.http.HttpStatus;
 import org.edx.mobile.http.HttpStatusException;
@@ -19,10 +20,7 @@ import java.io.IOException;
 
 import okhttp3.Call;
 import okhttp3.Callback;
-import okhttp3.MediaType;
 import okhttp3.Request;
-import okhttp3.ResponseBody;
-import retrofit2.Response;
 
 /**
  * Common webview helper for any view that needs to use a webview.
@@ -149,9 +147,7 @@ public class WebViewUtil {
                                         final int responseCode = response.code();
                                         if (responseCode >= HttpStatus.BAD_REQUEST) {
                                             errorNotification.showError(context,
-                                                    new HttpStatusException(Response.error(responseCode,
-                                                            ResponseBody.create(MediaType.parse("text/plain"),
-                                                                    response.message()))),
+                                                    new HttpStatusException(responseCode, response.message()),
                                                     actionTextResId, actionListener);
                                             viewInterface.hideLoadingProgress();
                                             viewInterface.clearWebView();

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/BaseWebViewFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/BaseWebViewFragment.java
@@ -27,10 +27,6 @@ import org.edx.mobile.view.custom.URLInterceptorWebViewClient;
 
 import javax.inject.Inject;
 
-import okhttp3.MediaType;
-import okhttp3.ResponseBody;
-import retrofit2.Response;
-
 /**
  * An abstract fragment providing basic functionality for URL interception, its follow up action,
  * error handling and show page progress based on page status.
@@ -171,8 +167,7 @@ public abstract class BaseWebViewFragment extends OfflineSupportBaseFragment
         public void onPageLoadError(WebView view, int errorCode, String description,
                                     String failingUrl) {
             errorNotification.showError(getContext(),
-                    new HttpStatusException(Response.error(HttpStatus.SERVICE_UNAVAILABLE,
-                            ResponseBody.create(MediaType.parse("text/plain"), description))),
+                    new HttpStatusException(HttpStatus.SERVICE_UNAVAILABLE, description),
                     R.string.lbl_reload, new View.OnClickListener() {
                         @Override
                         public void onClick(View v) {
@@ -189,9 +184,7 @@ public abstract class BaseWebViewFragment extends OfflineSupportBaseFragment
                                     boolean isMainRequestFailure) {
             if (isMainRequestFailure) {
                 errorNotification.showError(getContext(),
-                        new HttpStatusException(Response.error(errorResponse.getStatusCode(),
-                                ResponseBody.create(MediaType.parse(errorResponse.getMimeType()),
-                                        errorResponse.getReasonPhrase()))),
+                        new HttpStatusException(errorResponse.getStatusCode(), errorResponse.getReasonPhrase(), errorResponse.getMimeType()),
                         R.string.lbl_reload, new View.OnClickListener() {
                             @Override
                             public void onClick(View v) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseOutlineAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseOutlineAdapter.java
@@ -637,7 +637,7 @@ public class CourseOutlineAdapter extends BaseAdapter {
         upgradeBtnText.setOnClickListener(view1 -> CourseModalDialogFragment.newInstance(
                         Analytics.Screens.PLS_COURSE_DASHBOARD,
                         courseData.getCourseId(),
-                        courseData.getProductSku(),
+                        courseData.getCourseSku(),
                         courseData.getCourse().getName(),
                         courseData.getCourse().isSelfPaced())
                 .show(((AppCompatActivity) context).getSupportFragmentManager(),

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseUnitPagerAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseUnitPagerAdapter.java
@@ -84,7 +84,7 @@ public class CourseUnitPagerAdapter extends FragmentStateAdapter {
                 minifiedUnit = new HtmlBlockModel((HtmlBlockModel) unit);
             } else minifiedUnit = new CourseComponent(unit);
         }
-        minifiedUnit.setProductSku(courseData.getProductSku());
+        minifiedUnit.setCourseSku(courseData.getCourseSku());
         CourseUnitFragment unitFragment;
         final boolean isYoutubeVideo = (minifiedUnit instanceof VideoBlockModel && ((VideoBlockModel) minifiedUnit).getData().encodedVideos.getYoutubeVideoInfo() != null);
         if (minifiedUnit.getAuthorizationDenialReason() == AuthorizationDenialReason.FEATURE_BASED_ENROLLMENTS) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/AlertDialogFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/AlertDialogFragment.java
@@ -323,8 +323,7 @@ public class AlertDialogFragment extends DialogFragment {
                 neutralButton.setTypeface(null, Typeface.BOLD);
             }
         });
-        final boolean isCancelable = args.getBoolean(ARG_IS_CANCELABLE, true);
-        alertDialog.setCancelable(isCancelable);
+        setCancelable(args.getBoolean(ARG_IS_CANCELABLE, true));
         return alertDialog;
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
@@ -1,11 +1,9 @@
 package org.edx.mobile.view.dialog
 
-import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.annotation.StringRes
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -21,9 +19,12 @@ import org.edx.mobile.extenstion.setVisibility
 import org.edx.mobile.http.HttpStatus
 import org.edx.mobile.inapppurchases.BillingProcessor
 import org.edx.mobile.module.analytics.Analytics.Events
-import org.edx.mobile.module.analytics.Analytics.Values
 import org.edx.mobile.module.analytics.InAppPurchasesAnalytics
-import org.edx.mobile.util.*
+import org.edx.mobile.util.AppConstants
+import org.edx.mobile.util.InAppPurchasesException
+import org.edx.mobile.util.InAppPurchasesUtils
+import org.edx.mobile.util.NonNullObserver
+import org.edx.mobile.util.ResourceUtil
 import org.edx.mobile.viewModel.InAppPurchasesViewModel
 import javax.inject.Inject
 
@@ -46,6 +47,9 @@ class CourseModalDialogFragment : DialogFragment() {
 
     @Inject
     lateinit var iapAnalytics: InAppPurchasesAnalytics
+
+    @Inject
+    lateinit var iapUtils: InAppPurchasesUtils
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -110,7 +114,7 @@ class CourseModalDialogFragment : DialogFragment() {
             iapAnalytics.trackIAPEvent(eventName = Events.IAP_UPGRADE_NOW_CLICKED)
             courseSku?.let {
                 iapViewModel.addProductToBasket(it)
-            } ?: showUpgradeErrorDialog()
+            } ?: iapUtils.showUpgradeErrorDialog(this)
         }
         billingProcessor =
             BillingProcessor(requireContext(), object : BillingProcessor.BillingFlowListeners {
@@ -127,7 +131,8 @@ class CourseModalDialogFragment : DialogFragment() {
 
                 override fun onPurchaseCancel(responseCode: Int, message: String) {
                     iapViewModel.endLoading()
-                    showUpgradeErrorDialog(
+                    iapUtils.showUpgradeErrorDialog(
+                        context = this@CourseModalDialogFragment,
                         errorResId = R.string.error_payment_not_processed,
                         errorCode = responseCode,
                         errorMessage = message,
@@ -165,7 +170,8 @@ class CourseModalDialogFragment : DialogFragment() {
                     iapAnalytics.setPrice(skuDetail.price)
                     iapAnalytics.trackIAPEvent(Events.IAP_LOAD_PRICE_TIME)
                 } else {
-                    showUpgradeErrorDialog(
+                    iapUtils.showUpgradeErrorDialog(
+                        context = this@CourseModalDialogFragment,
                         errorResId = R.string.error_price_not_fetched,
                         errorType = ErrorMessage.PRICE_CODE,
                         listener = { _, _ ->
@@ -173,7 +179,8 @@ class CourseModalDialogFragment : DialogFragment() {
                         })
                 }
             }
-        } ?: showUpgradeErrorDialog(
+        } ?: iapUtils.showUpgradeErrorDialog(
+            context = this@CourseModalDialogFragment,
             errorResId = R.string.error_price_not_fetched,
             errorType = ErrorMessage.PRICE_CODE,
             listener = { _, _ ->
@@ -204,15 +211,36 @@ class CourseModalDialogFragment : DialogFragment() {
                         )
                         return@NonNullObserver
                     }
-                    else -> showUpgradeErrorDialog(
-                        errorMsg.errorResId,
-                        errorMsg.throwable.httpErrorCode,
-                        errorMsg.throwable.errorMessage,
-                        errorMsg.errorCode
+                    HttpStatus.NOT_ACCEPTABLE -> {
+                        iapUtils.showPostUpgradeErrorDialog(
+                            context = this@CourseModalDialogFragment,
+                            errorResId = errorMsg.errorResId,
+                            errorCode = errorMsg.throwable.httpErrorCode,
+                            errorMessage = errorMsg.throwable.errorMessage,
+                            errorType = errorMsg.errorCode,
+                            retryListener = { _, _ ->
+                                iapViewModel.upgradeMode =
+                                    InAppPurchasesViewModel.UpgradeMode.SILENT
+                                iapViewModel.showFullScreenLoader(true)
+                                dismiss()
+                            },
+                            cancelListener = null
+                        )
+                    }
+                    else -> iapUtils.showUpgradeErrorDialog(
+                        context = this@CourseModalDialogFragment,
+                        errorResId = errorMsg.errorResId,
+                        errorCode = errorMsg.throwable.httpErrorCode,
+                        errorMessage = errorMsg.throwable.errorMessage,
+                        errorType = errorMsg.errorCode
                     )
                 }
             } else {
-                showUpgradeErrorDialog(errorMsg.errorResId, errorType = errorMsg.errorCode)
+                iapUtils.showUpgradeErrorDialog(
+                    context = this@CourseModalDialogFragment,
+                    errorResId = errorMsg.errorResId,
+                    errorType = errorMsg.errorCode
+                )
             }
             iapViewModel.errorMessageShown()
         })
@@ -224,7 +252,11 @@ class CourseModalDialogFragment : DialogFragment() {
     }
 
     private fun purchaseProduct(productId: String) {
-        activity?.let { billingProcessor?.purchaseItem(it, productId) }
+        activity?.let { context ->
+            environment.loginPrefs.userId?.let { userId ->
+                billingProcessor?.purchaseItem(context, productId, userId)
+            }
+        }
     }
 
     private fun onProductPurchased(purchaseToken: String) {
@@ -235,80 +267,6 @@ class CourseModalDialogFragment : DialogFragment() {
             iapViewModel.showFullScreenLoader(true)
             dismiss()
         }
-    }
-
-    private fun showUpgradeErrorDialog(
-        @StringRes errorResId: Int = R.string.general_error_message,
-        errorCode: Int? = null,
-        errorMessage: String? = null,
-        errorType: Int? = null,
-        listener: DialogInterface.OnClickListener? = null
-    ) {
-        // To restrict showing error dialog on an unattached fragment
-        if (!isAdded) return
-        val feedbackErrorMessage: String = TextUtils.getFormattedErrorMessage(
-            errorCode,
-            errorType,
-            errorMessage
-        ).toString()
-
-        when (errorType) {
-            ErrorMessage.PAYMENT_SDK_CODE -> iapAnalytics.trackIAPEvent(
-                eventName = Events.IAP_PAYMENT_ERROR,
-                errorMsg = feedbackErrorMessage
-            )
-            ErrorMessage.PRICE_CODE -> iapAnalytics.trackIAPEvent(
-                eventName = Events.IAP_PRICE_LOAD_ERROR,
-                errorMsg = feedbackErrorMessage
-            )
-            else -> iapAnalytics.trackIAPEvent(
-                eventName = Events.IAP_COURSE_UPGRADE_ERROR,
-                errorMsg = feedbackErrorMessage
-            )
-        }
-
-        AlertDialogFragment.newInstance(
-            getString(R.string.title_upgrade_error),
-            getString(errorResId),
-            getString(if (listener != null) R.string.try_again else R.string.label_close),
-            { dialogInterface, i ->
-                listener?.onClick(dialogInterface, i).also {
-                    iapAnalytics.trackIAPEvent(
-                        eventName = Events.IAP_ERROR_ALERT_ACTION,
-                        errorMsg = feedbackErrorMessage,
-                        actionTaken = Values.ACTION_RELOAD_PRICE
-                    )
-                } ?: run {
-                    iapAnalytics.trackIAPEvent(
-                        eventName = Events.IAP_ERROR_ALERT_ACTION,
-                        errorMsg = feedbackErrorMessage,
-                        actionTaken = Values.ACTION_CLOSE
-                    )
-                }
-            },
-            getString(if (listener != null) R.string.label_cancel else R.string.label_get_help),
-            { _, _ ->
-                listener?.also {
-                    iapAnalytics.trackIAPEvent(
-                        eventName = Events.IAP_ERROR_ALERT_ACTION,
-                        errorMsg = feedbackErrorMessage,
-                        actionTaken = Values.ACTION_CLOSE
-                    )
-                    dismiss()
-                } ?: run {
-                    environment.router?.showFeedbackScreen(
-                        requireActivity(),
-                        getString(R.string.email_subject_upgrade_error),
-                        feedbackErrorMessage
-                    )
-                    iapAnalytics.trackIAPEvent(
-                        eventName = Events.IAP_ERROR_ALERT_ACTION,
-                        errorMsg = feedbackErrorMessage,
-                        actionTaken = Values.ACTION_GET_HELP
-                    )
-                }
-            }, false
-        ).show(childFragmentManager, null)
     }
 
     override fun onDestroyView() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/CourseDateViewModel.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/CourseDateViewModel.kt
@@ -9,8 +9,6 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.ResponseBody
 import org.edx.mobile.exception.ErrorMessage
 import org.edx.mobile.http.HttpStatusException
 import org.edx.mobile.http.constants.ApiConstants
@@ -21,7 +19,6 @@ import org.edx.mobile.model.course.CourseDates
 import org.edx.mobile.model.course.ResetCourseDates
 import org.edx.mobile.repositorie.CourseDatesRepository
 import org.edx.mobile.util.CalendarUtils
-import retrofit2.Response
 import java.util.*
 import javax.inject.Inject
 
@@ -213,13 +210,6 @@ class CourseDateViewModel @Inject constructor(
     }
 
     fun setError(errorCode: Int, httpStatusCode: Int, msg: String) {
-        _errorMessage.value = ErrorMessage(
-            errorCode, HttpStatusException(
-                Response.error<Any>(
-                    httpStatusCode,
-                    ResponseBody.create("text/plain".toMediaTypeOrNull(), msg)
-                )
-            )
-        )
+        _errorMessage.value = ErrorMessage(errorCode, HttpStatusException(httpStatusCode, msg))
     }
 }


### PR DESCRIPTION
### Description

[LEARNER-8693](https://2u-internal.atlassian.net/browse/LEARNER-8693)

- Handle multiple unfulfilled and externally-fulfilled IAPs
- Added obfuscated user Id Playsotre with purchase as metadata

<img height="500" alt="Screenshot 2022-06-09 at 1 25 06 AM" src="https://user-images.githubusercontent.com/71447999/172716606-77177d48-a0c6-4547-aa37-04a4015cb809.png">

### Some Testing Use Cases
- [ ] Handle IAP with `Refresh Now` option
- [ ] Handle IAP with `Continue Without Update`
- [ ] Perform normal IAP after handling the unfulfilled purchase
- [ ] Trying to purchase an unfulfilled course
- [ ] Test unfulfilled purchase of another user 

### Some Error Handling Use Cases
- [ ] Error on `execute` during the unfulfilled purchase handling
- [ ] Error on `refresh` during the unfulfilled purchase handling

</br>