### PR TITLE
fix: Resolve Hilt Injection and Scoping Issues

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/authentication/LoginAPI.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/authentication/LoginAPI.java
@@ -30,9 +30,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import dagger.Module;
-import dagger.hilt.InstallIn;
-import dagger.hilt.components.SingletonComponent;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Response;
@@ -40,10 +40,7 @@ import retrofit2.Response;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static org.edx.mobile.http.util.CallUtil.executeStrict;
 
-import javax.inject.Inject;
-
-@Module
-@InstallIn(SingletonComponent.class)
+@Singleton
 public class LoginAPI {
 
     @NonNull

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/core/EdxDefaultModule.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/core/EdxDefaultModule.kt
@@ -36,6 +36,7 @@ import org.edx.mobile.repositorie.CourseDatesRepository
 import org.edx.mobile.repositorie.InAppPurchasesRepository
 import org.edx.mobile.services.CourseManager
 import org.edx.mobile.services.EdxCookieManager
+import org.edx.mobile.user.UserAPI
 import org.edx.mobile.user.UserService
 import retrofit2.Retrofit
 import javax.inject.Singleton
@@ -126,6 +127,8 @@ abstract class EdxDefaultModule {
         fun getEnvironment(): IEdxEnvironment
 
         fun getLoginAPI(): LoginAPI
+
+        fun getUserAPI(): UserAPI
 
         fun getLoginPrefs(): LoginPrefs
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/core/EdxEnvironment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/core/EdxEnvironment.java
@@ -13,14 +13,11 @@ import org.edx.mobile.util.Config;
 import org.edx.mobile.view.Router;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
-import dagger.Module;
-import dagger.hilt.InstallIn;
-import dagger.hilt.components.SingletonComponent;
 import de.greenrobot.event.EventBus;
 
-@Module
-@InstallIn(SingletonComponent.class)
+@Singleton
 public class EdxEnvironment implements IEdxEnvironment {
 
     @Inject

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/provider/OkHttpClientProvider.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/provider/OkHttpClientProvider.java
@@ -20,11 +20,9 @@ import java.util.List;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
+import javax.inject.Singleton;
 
-import dagger.Module;
-import dagger.hilt.InstallIn;
 import dagger.hilt.android.qualifiers.ApplicationContext;
-import dagger.hilt.components.SingletonComponent;
 import okhttp3.Cache;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
@@ -41,8 +39,7 @@ public interface OkHttpClientProvider extends Provider<OkHttpClient> {
     @NonNull
     OkHttpClient getNonOAuthBased();
 
-    @Module
-    @InstallIn(SingletonComponent.class)
+    @Singleton
     class Impl implements OkHttpClientProvider {
         private static final int cacheSize = 10 * 1024 * 1024; // 10 MiB
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/provider/RetrofitProvider.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/provider/RetrofitProvider.java
@@ -7,10 +7,8 @@ import com.google.gson.Gson;
 import org.edx.mobile.util.Config;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
-import dagger.Module;
-import dagger.hilt.InstallIn;
-import dagger.hilt.components.SingletonComponent;
 import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
@@ -29,8 +27,7 @@ public interface RetrofitProvider {
     @NonNull
     Retrofit getIAPAuth();
 
-    @Module
-    @InstallIn(SingletonComponent.class)
+    @Singleton
     class Impl implements RetrofitProvider {
         private static final int CLIENT_INDEX_DEFAULT = 0;
         private static final int CLIENT_INDEX_WITH_OFFLINE_CACHE = 1;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/instrumentation/EndEmmaBroadcast.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/instrumentation/EndEmmaBroadcast.java
@@ -10,8 +10,11 @@ import org.edx.mobile.logger.Logger;
 
 import java.io.File;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
 // adb shell am broadcast -a com.example.pkg.END_EMMA
 @SuppressLint("SdCardPath")
+@AndroidEntryPoint
 public class EndEmmaBroadcast extends BroadcastReceiver {
     protected final Logger logger = new Logger(getClass().getName());
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/db/DownloadEntry.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/db/DownloadEntry.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.text.TextUtils;
 
 import org.edx.mobile.R;
-import org.edx.mobile.core.IEdxEnvironment;
 import org.edx.mobile.interfaces.SectionItemInterface;
 import org.edx.mobile.model.VideoModel;
 import org.edx.mobile.model.api.EncodingsModel;
@@ -13,7 +12,6 @@ import org.edx.mobile.model.download.NativeDownloadModel;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.util.JavaUtil;
 
-import javax.inject.Inject;
 
 public class DownloadEntry implements SectionItemInterface, VideoModel {
 
@@ -54,9 +52,6 @@ public class DownloadEntry implements SectionItemInterface, VideoModel {
      * available to cast in deep-link case after this TODO this issue will resolved.
      */
     public String videoThumbnail;
-
-    @Inject
-    IEdxEnvironment environment;
 
     /**
      * Returns duration in the readable format i.e. hh:mm:ss. Returns null if duration is zero or

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/FirebaseAnalytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/FirebaseAnalytics.java
@@ -16,17 +16,14 @@ import org.edx.mobile.util.images.ShareUtils;
 import java.util.Map;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
-import dagger.Module;
-import dagger.hilt.InstallIn;
 import dagger.hilt.android.qualifiers.ApplicationContext;
-import dagger.hilt.components.SingletonComponent;
 
 /**
  * A concrete implementation of {@link Analytics} to report all the screens and events to Firebase.
  */
-@Module
-@InstallIn(SingletonComponent.class)
+@Singleton
 public class FirebaseAnalytics implements Analytics {
 
     protected final Logger logger = new Logger(getClass().getName());

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/SegmentAnalytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/SegmentAnalytics.java
@@ -29,17 +29,14 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
-import dagger.Module;
-import dagger.hilt.InstallIn;
 import dagger.hilt.android.qualifiers.ApplicationContext;
-import dagger.hilt.components.SingletonComponent;
 
 /**
  * A concrete implementation of {@link Analytics} to report all the screens and events to Segment.
  */
-@Module
-@InstallIn(SingletonComponent.class)
+@Singleton
 public class SegmentAnalytics implements Analytics {
 
     protected final Logger logger = new Logger(getClass().getName());

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/impl/IDatabaseImpl.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/impl/IDatabaseImpl.java
@@ -23,14 +23,11 @@ import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
-import dagger.Module;
-import dagger.hilt.InstallIn;
 import dagger.hilt.android.qualifiers.ApplicationContext;
-import dagger.hilt.components.SingletonComponent;
 
-@Module
-@InstallIn(SingletonComponent.class)
+@Singleton
 public class IDatabaseImpl extends IDatabaseBaseImpl implements IDatabase {
 
     @Inject

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/download/IDownloadManagerImpl.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/download/IDownloadManagerImpl.java
@@ -16,14 +16,11 @@ import org.edx.mobile.util.Sha1Util;
 import java.io.File;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
-import dagger.Module;
-import dagger.hilt.InstallIn;
 import dagger.hilt.android.qualifiers.ApplicationContext;
-import dagger.hilt.components.SingletonComponent;
 
-@Module
-@InstallIn(SingletonComponent.class)
+@Singleton
 public class IDownloadManagerImpl implements IDownloadManager {
 
     private final Context context;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
@@ -18,14 +18,11 @@ import org.edx.mobile.user.ProfileImage;
 import org.edx.mobile.util.VideoPlaybackSpeed;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
-import dagger.Module;
-import dagger.hilt.InstallIn;
 import dagger.hilt.android.qualifiers.ApplicationContext;
-import dagger.hilt.components.SingletonComponent;
 
-@Module
-@InstallIn(SingletonComponent.class)
+@Singleton
 public class LoginPrefs {
 
     public enum AuthBackend {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/UserPrefs.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/UserPrefs.kt
@@ -1,15 +1,12 @@
 package org.edx.mobile.module.prefs
 
 import android.content.Context
-import dagger.Module
-import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
-import dagger.hilt.components.SingletonComponent
 import org.edx.mobile.model.api.ProfileModel
 import javax.inject.Inject
+import javax.inject.Singleton
 
-@Module
-@InstallIn(SingletonComponent::class)
+@Singleton
 class UserPrefs @Inject constructor(
     @ApplicationContext val context: Context, val loginPrefs: LoginPrefs
 ) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/storage/Storage.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/storage/Storage.java
@@ -37,16 +37,13 @@ import java.io.FileInputStream;
 import java.util.List;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import dagger.Lazy;
-import dagger.Module;
-import dagger.hilt.InstallIn;
 import dagger.hilt.android.qualifiers.ApplicationContext;
-import dagger.hilt.components.SingletonComponent;
 import de.greenrobot.event.EventBus;
 
-@Module
-@InstallIn(SingletonComponent.class)
+@Singleton
 public class Storage implements IStorage {
 
     private final Context context;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/player/TranscriptManager.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/player/TranscriptManager.java
@@ -23,16 +23,13 @@ import java.io.InputStream;
 import java.nio.charset.Charset;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
-import dagger.Module;
-import dagger.hilt.InstallIn;
 import dagger.hilt.android.qualifiers.ApplicationContext;
-import dagger.hilt.components.SingletonComponent;
 import subtitleFile.FormatSRT;
 import subtitleFile.TimedTextObject;
 
-@Module
-@InstallIn(SingletonComponent.class)
+@Singleton
 public class TranscriptManager {
 
     private final Logger logger = new Logger(getClass().getName());

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/receivers/MediaStatusReceiver.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/receivers/MediaStatusReceiver.java
@@ -21,11 +21,13 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
 import de.greenrobot.event.EventBus;
 
 /**
  * BroadcastReceiver to receive the removable storage (such as SD-card) status events.
  */
+@AndroidEntryPoint
 public class MediaStatusReceiver extends BroadcastReceiver {
 
     @Inject

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/services/DownloadSpeedService.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/services/DownloadSpeedService.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.OkHttpClient;
@@ -33,6 +34,7 @@ import okhttp3.Response;
 /**
  * Created by marcashman on 2014-12-01.
  */
+@AndroidEntryPoint
 public class DownloadSpeedService extends Service {
 
     private static final String TAG = DownloadSpeedService.class.getCanonicalName();

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/services/VideoDownloadHelper.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/services/VideoDownloadHelper.java
@@ -28,14 +28,11 @@ import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
-import dagger.Module;
-import dagger.hilt.InstallIn;
-import dagger.hilt.components.SingletonComponent;
 import de.greenrobot.event.EventBus;
 
-@Module
-@InstallIn(SingletonComponent.class)
+@Singleton
 public class VideoDownloadHelper {
     public interface DownloadManagerCallback {
         void onDownloadStarted(Long result);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/social/SocialFactory.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/social/SocialFactory.java
@@ -9,12 +9,7 @@ import org.edx.mobile.social.microsoft.MicrosoftAuth;
 import org.edx.mobile.util.Config;
 import org.edx.mobile.util.NetworkUtil;
 
-import javax.inject.Inject;
-
 public class SocialFactory {
-
-    @Inject
-    Config config;
 
     //TODO - we should create a central place for application wide constants.
     public enum SOCIAL_SOURCE_TYPE {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/user/DeleteAccountImageTask.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/user/DeleteAccountImageTask.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 import dagger.hilt.android.EntryPointAccessors;
 import de.greenrobot.event.EventBus;
 
-public class DeleteAccountImageTask extends Task<Object> {
+public class DeleteAccountImageTask extends Task<Void> {
 
     UserService userService;
     LoginPrefs loginPrefs;
@@ -43,7 +43,7 @@ public class DeleteAccountImageTask extends Task<Object> {
     }
 
     @Override
-    protected void onPostExecute(Object unused) {
+    protected void onPostExecute(Void unused) {
         super.onPostExecute(unused);
         EventBus.getDefault().post(new ProfilePhotoUpdatedEvent(username, null));
         // Delete the logged in user's ProfileImage

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/user/SetAccountImageTask.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/user/SetAccountImageTask.java
@@ -6,6 +6,7 @@ import android.net.Uri;
 
 import androidx.annotation.NonNull;
 
+import org.edx.mobile.core.EdxDefaultModule;
 import org.edx.mobile.event.ProfilePhotoUpdatedEvent;
 import org.edx.mobile.task.Task;
 import org.edx.mobile.third_party.crop.CropUtil;
@@ -13,13 +14,11 @@ import org.edx.mobile.third_party.crop.CropUtil;
 import java.io.File;
 import java.io.IOException;
 
-import javax.inject.Inject;
-
+import dagger.hilt.android.EntryPointAccessors;
 import de.greenrobot.event.EventBus;
 
-public class SetAccountImageTask extends Task<Object> {
+public class SetAccountImageTask extends Task<Void> {
 
-    @Inject
     UserAPI userAPI;
 
     @NonNull
@@ -36,6 +35,8 @@ public class SetAccountImageTask extends Task<Object> {
         this.username = username;
         this.uri = uri;
         this.cropRect = cropRect;
+        this.userAPI = EntryPointAccessors.fromApplication(
+                context, EdxDefaultModule.ProviderEntryPoint.class).getUserAPI();
     }
 
     @Override
@@ -53,7 +54,7 @@ public class SetAccountImageTask extends Task<Object> {
     }
 
     @Override
-    protected void onPostExecute(Object unused) {
+    protected void onPostExecute(Void unused) {
         super.onPostExecute(unused);
         EventBus.getDefault().post(new ProfilePhotoUpdatedEvent(username, uri));
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/user/UserAPI.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/user/UserAPI.java
@@ -18,19 +18,16 @@ import org.edx.mobile.view.common.TaskProgressCallback;
 import java.io.File;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
-import dagger.Module;
-import dagger.hilt.InstallIn;
 import dagger.hilt.android.EntryPointAccessors;
-import dagger.hilt.components.SingletonComponent;
 import de.greenrobot.event.EventBus;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 
-@Module
-@InstallIn(SingletonComponent.class)
+@Singleton
 public class UserAPI {
 
     UserService userService;
@@ -40,8 +37,7 @@ public class UserAPI {
         this.userService = userService;
     }
 
-    @Module
-    @InstallIn(SingletonComponent.class)
+    @Singleton
     public static class AccountDataUpdatedCallback extends ErrorHandlingCallback<Account> {
 
         @NonNull

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/user/UserAPI.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/user/UserAPI.java
@@ -33,8 +33,12 @@ import retrofit2.Call;
 @InstallIn(SingletonComponent.class)
 public class UserAPI {
 
-    @Inject
     UserService userService;
+
+    @Inject
+    public UserAPI(@NonNull UserService userService) {
+        this.userService = userService;
+    }
 
     @Module
     @InstallIn(SingletonComponent.class)

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/Config.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/Config.java
@@ -26,14 +26,11 @@ import java.util.List;
 import java.util.Locale;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
-import dagger.Module;
-import dagger.hilt.InstallIn;
 import dagger.hilt.android.qualifiers.ApplicationContext;
-import dagger.hilt.components.SingletonComponent;
 
-@Module
-@InstallIn(SingletonComponent.class)
+@Singleton
 public class Config {
 
     private static final Logger logger = new Logger(Config.class.getName());

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
@@ -41,12 +41,10 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import dagger.Module;
-import dagger.hilt.InstallIn;
 import dagger.hilt.android.AndroidEntryPoint;
 import dagger.hilt.android.EntryPointAccessors;
-import dagger.hilt.android.components.FragmentComponent;
 import dagger.hilt.android.qualifiers.ActivityContext;
+import dagger.hilt.android.scopes.FragmentScoped;
 import de.greenrobot.event.EventBus;
 import retrofit2.Call;
 
@@ -240,8 +238,7 @@ public class CourseDiscussionResponsesFragment extends BaseFragment implements C
         router.showCourseDiscussionComments(getActivity(), response, discussionThread, courseData);
     }
 
-    @Module
-    @InstallIn(FragmentComponent.class)
+    @FragmentScoped
     static class ResponsesLoader implements
             InfiniteScrollUtils.PageLoader<DiscussionComment> {
         @NonNull

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/EditUserProfileFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/EditUserProfileFragment.java
@@ -174,7 +174,7 @@ public class EditUserProfileFragment extends BaseFragment implements BaseFragmen
                                 break;
                             }
                             case R.id.remove_photo: {
-                                final Task task = new DeleteAccountImageTask(getActivity(), username);
+                                final Task<Void> task = new DeleteAccountImageTask(getActivity(), username);
                                 task.setProgressDialog(viewHolder.profileImageProgress);
                                 executePhotoTask(task);
                                 break;
@@ -193,7 +193,7 @@ public class EditUserProfileFragment extends BaseFragment implements BaseFragmen
         username = getArguments().getString(EditUserProfileActivity.EXTRA_USERNAME);
     }
 
-    private void executePhotoTask(Task task) {
+    private void executePhotoTask(Task<Void> task) {
         viewHolder.profileImageProgress.setVisibility(View.VISIBLE);
         // TODO: Test this with "Don't keep activities"
         if (null != setAccountImageTask) {
@@ -434,7 +434,7 @@ public class EditUserProfileFragment extends BaseFragment implements BaseFragmen
                 final Uri imageUri = CropImageActivity.getImageUriFromResult(data);
                 final Rect cropRect = CropImageActivity.getCropRectFromResult(data);
                 if (null != imageUri && null != cropRect) {
-                    final Task task = new SetAccountImageTask(getActivity(), username, imageUri, cropRect);
+                    final Task<Void> task = new SetAccountImageTask(getActivity(), username, imageUri, cropRect);
                     task.setProgressDialog(viewHolder.profileImageProgress);
                     executePhotoTask(task);
                     analyticsRegistry.trackProfilePhotoSet(CropImageActivity.isResultFromCamera(data));

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
@@ -34,19 +34,14 @@ import org.edx.mobile.util.Config;
 import org.edx.mobile.util.EmailUtil;
 import org.edx.mobile.util.ResourceUtil;
 import org.edx.mobile.util.SecurityUtil;
-import org.edx.mobile.util.TextUtils;
 import org.edx.mobile.util.links.WebViewLink;
 import org.edx.mobile.view.dialog.WebViewActivity;
 import org.edx.mobile.whatsnew.WhatsNewActivity;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
-import dagger.Module;
-import dagger.hilt.InstallIn;
-import dagger.hilt.components.SingletonComponent;
-
-@Module
-@InstallIn(SingletonComponent.class)
+@Singleton
 public class Router {
     public static final String EXTRA_ANNOUNCEMENTS = "announcements";
     public static final String EXTRA_BUNDLE = "bundle";

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CCLanguageDialogFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CCLanguageDialogFragment.java
@@ -21,6 +21,9 @@ import java.util.LinkedHashMap;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
+@AndroidEntryPoint
 public class CCLanguageDialogFragment extends DialogFragment {
 
     private final Logger logger = new Logger(getClass().getName());

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/ResetPasswordDialogFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/ResetPasswordDialogFragment.java
@@ -27,8 +27,10 @@ import org.edx.mobile.util.images.ErrorUtils;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
 import retrofit2.Call;
 
+@AndroidEntryPoint
 public class ResetPasswordDialogFragment extends DialogFragment {
     private static final String ARG_LOGIN_EMAIL = "login_email";
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/SpeedDialogFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/SpeedDialogFragment.java
@@ -20,6 +20,9 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
+@AndroidEntryPoint
 public class SpeedDialogFragment extends DialogFragment {
 
     public interface IListDialogCallback {


### PR DESCRIPTION
### Description

[LEARNER-8900](https://2u-internal.atlassian.net/browse/LEARNER-8900)

- Inject dependencies into Broadcast Receivers & Services.
- Inject missing dependencies on Fragments.

### Resolved Hilt Scoping Issue
- **@InstallIn(SingletonComponent::class)**: To keep the instance/s for the lifetime of the application. 
( Hilt Modules are used where we cannot constructor-inject a type i.e Interface or external library - [doc](https://developer.android.com/training/dependency-injection/hilt-android#hilt-modules) )
- **@Singleton**: To keep the instance application-wide singleton

To get the same instance of the object we have refactored **@InstallIn(SingletonComponent::class)** to **@Singleton**.

### References
- https://medium.com/digigeek/hilt-components-and-scopes-in-android-b96546cb07df
- https://developer.android.com/training/dependency-injection/hilt-android#generated-components