### PR TITLE
fix: Play downloaded videos in Offline mode

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/player/VideoPlayer.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/player/VideoPlayer.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.Point;
 import android.net.Uri;
 import android.view.View.OnClickListener;
+import android.webkit.URLUtil;
 
 import androidx.annotation.NonNull;
 
@@ -20,6 +21,7 @@ import com.google.android.exoplayer2.source.hls.HlsMediaSource;
 import com.google.android.exoplayer2.ui.PlayerView;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
+import com.google.android.exoplayer2.upstream.FileDataSource;
 import com.google.android.exoplayer2.util.Util;
 
 import org.edx.mobile.R;
@@ -186,6 +188,9 @@ public class VideoPlayer implements Player.Listener, AnalyticsListener, PlayerLi
                 if (callback != null) {
                     callback.onPrepared();
                 }
+                if (exoPlayer.getPlayWhenReady()) {
+                    state = PlayerState.PLAYING;
+                }
                 break;
             case Player.STATE_ENDED:
                 // onPlayerStateChanged with Player.STATE_ENDED called twice after calling
@@ -295,10 +300,16 @@ public class VideoPlayer implements Player.Listener, AnalyticsListener, PlayerLi
         final MediaSource mediaSource;
 
         if (VideoUtil.videoHasFormat(videoUrl, AppConstants.VIDEO_FORMAT_M3U8)) {
-            mediaSource = new HlsMediaSource.Factory(dataSourceFactory)
+            mediaSource = new HlsMediaSource
+                    .Factory(dataSourceFactory)
+                    .createMediaSource(mediaItem);
+        } else if (URLUtil.isValidUrl(videoUrl)) {
+            mediaSource = new ProgressiveMediaSource
+                    .Factory(dataSourceFactory)
                     .createMediaSource(mediaItem);
         } else {
-            mediaSource = new ProgressiveMediaSource.Factory(dataSourceFactory)
+            mediaSource = new ProgressiveMediaSource
+                    .Factory(new FileDataSource.Factory())
                     .createMediaSource(mediaItem);
         }
         return mediaSource;


### PR DESCRIPTION
### Description

[LEARNER-8876](https://2u-internal.atlassian.net/browse/LEARNER-8876)

- Updated DataSource from `DefaultHttpDataSource` to `FileDataSource` for offline videos
- Reverted PlayerState's value change from [LEARNER-8354](https://2u-internal.atlassian.net/browse/LEARNER-8354) - [Code Ref](https://github.com/openedx/edx-app-android/pull/1631/files#diff-02d2c9f5753796df3bffa4cf8be90c9bcd40045dec92ec64f4e7d99be768770aL184:~:text=(playWhenReady)%20%7B-,state%20%3D%20PlayerState.PLAYING%3B,-%7D)

