### PR TITLE
fix: disable main dashboard horizontal scroll

### DIFF
--- a/OpenEdXMobile/res/layout/activity_single_fragment_base.xml
+++ b/OpenEdXMobile/res/layout/activity_single_fragment_base.xml
@@ -42,6 +42,16 @@
 
                 </RelativeLayout>
 
+                <com.google.android.material.tabs.TabLayout
+                    android:id="@+id/tabs"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@color/toolbar_background_color"
+                    android:visibility="gone"
+                    app:tabGravity="fill"
+                    app:tabMaxWidth="0dp"
+                    tools:visibility="visible" />
+
                 <include
                     android:id="@+id/auth_panel"
                     layout="@layout/auth_panel" />

--- a/OpenEdXMobile/res/layout/toolbar.xml
+++ b/OpenEdXMobile/res/layout/toolbar.xml
@@ -14,14 +14,4 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
-    <com.google.android.material.tabs.TabLayout
-        android:id="@+id/tabs"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@color/toolbar_background_color"
-        android:visibility="gone"
-        app:tabGravity="fill"
-        app:tabMaxWidth="0dp"
-        tools:visibility="visible" />
-
 </com.google.android.material.appbar.AppBarLayout>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/MainTabsDashboardFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/MainTabsDashboardFragment.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.View;
 
 import androidx.annotation.NonNull;
 
@@ -28,6 +29,12 @@ public class MainTabsDashboardFragment extends TabsBaseFragment {
         super.onCreate(savedInstanceState);
         setHasOptionsMenu(true);
         EventBus.getDefault().register(this);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        binding.viewPager2.setUserInputEnabled(false);
     }
 
     @Override

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/TabsBaseFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/TabsBaseFragment.java
@@ -58,7 +58,7 @@ public abstract class TabsBaseFragment extends BaseFragment {
     }
 
     @Override
-    public void onViewCreated(View view, Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         // Enforce to intercept single scrolling direction
         if (binding != null) {


### PR DESCRIPTION
### Description

[LEARNER-8931](https://2u-internal.atlassian.net/browse/LEARNER-8931)

- Disable swipe on the main dashboard screen and move tabs to the bottom in support of the new discovery experience horizontal scrolling.

### Sample

https://user-images.githubusercontent.com/43750646/176108728-dc85d041-61b0-494d-97c8-79a236f04bda.mp4
