### PR TITLE
fix: error when using batch compelete api

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseService.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseService.java
@@ -161,6 +161,7 @@ public interface CourseService {
         String username;
 
         @NonNull
+        @SerializedName("course_key")
         String courseKey;
 
         @NonNull


### PR DESCRIPTION
### Description


This changes just adds a serlizesed name for courseKey which is used 
for batch complete API. The backend expect it to be snake_case, so
adding serlized name ensure it would be send in snake_case

[LEARNER-XXXX](https://2u-internal.atlassian.net/browse/LEARNER-XXXX)

Add a description of your changes here.

### Notes
- Example: Use example.sandbox.edx.org to test against
- Example: This PR will not address x,y, and z, because of a, b, and c.
- Example: Feature is behind a flag
- Example: Why I didn't add any tests

### Testing
- [ ] i18n
- [ ] RTL
- [ ] safecommit shows 0 violations
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Analytics
- [ ] Performance
- [ ] Database migrations are backwards-compatible
