### PR TITLE
fix: deep links aren't working on fresh install with payload

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -208,6 +208,7 @@ dependencies {
     }
     implementation "com.google.android.gms:play-services-ads-identifier:18.0.1"
     implementation "com.android.installreferrer:installreferrer:2.2"
+    implementation "androidx.browser:browser:1.3.0"
 
     //New Relic Integration
     implementation "com.newrelic.agent.android:android-agent:$newrelic_version"

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/SplashActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/SplashActivity.java
@@ -85,6 +85,7 @@ public class SplashActivity extends ComponentActivity {
                 }
             };
             Branch.sessionBuilder(this).withCallback(branchReferralInitListener)
+                    .withDelay(1000) // wait for 1 sec to complete the Initialization with payload.
                     .withData(getIntent() != null ? getIntent().getData() : null).init();
         }
         finish();


### PR DESCRIPTION
### Description

[LEARNER-8974](https://2u-internal.atlassian.net/browse/LEARNER-8974)

- Ad minor delay to complete branch.io initialization with the payload.
- Chrome Tab matching (enables 100% guaranteed matching based on cookies).

**References**:
- https://help.branch.io/developers-hub/docs/android-advanced-features#delay-branch-initialization
- https://help.branch.io/developers-hub/docs/android-basic-integration#install-branch

**How to test**:
- Fresh Install the app.
- Sig-in the user and redirect to the dates tab on any course having assignments(due components).
- Sync the calender.
- Open the calender and click on the link to open the purticular course compoenent.
- User should redirect to the course component on the first attempt.