### PR TITLE
fix: Open in Browser Dialog State loss issue

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/BrowserUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/BrowserUtil.java
@@ -47,15 +47,20 @@ public class BrowserUtil {
                 .toString();
         String positiveBtn = activity.getString(R.string.label_continue);
         String negativeBtn = activity.getString(R.string.label_cancel);
-        AlertDialogFragment.newInstance(title, msg,
+        AlertDialogFragment alertDialog = AlertDialogFragment.newInstance(title, msg,
                 positiveBtn, (dialog, which) -> {
                     analyticsRegistry.trackOpenInBrowserAlertActionTaken(url, Analytics.Values.ACTION_CONTINUE);
                     open(activity, url, canTrackEvent);
                 },
                 negativeBtn, (dialog, which) -> {
                     analyticsRegistry.trackOpenInBrowserAlertActionTaken(url, Analytics.Values.ACTION_CANCEL);
-                })
-                .show(activity.getSupportFragmentManager(), "");
+                });
+
+        activity.getSupportFragmentManager()
+                .beginTransaction()
+                .add(alertDialog, "")
+                .commitAllowingStateLoss();
+
         analyticsRegistry.trackOpenInBrowserAlertTriggerEvent(url);
     }
 


### PR DESCRIPTION
### Description

[LEARNER-8987](https://2u-internal.atlassian.net/browse/LEARNER-8987)

There was a delay of some kind causing dialog to be put on view after a call to onSaveInstanceState. View state was lost and trying to show a dialog on the lost state view was causing an exception.

We have now committed the dialog with the state loss flag set to true. It will prevent the app from raising an exception for this edge case.

Issue on Crashlytics: [BrowserUtil.java](https://console.firebase.google.com/u/1/project/openedx-mobile/crashlytics/app/android:org.edx.mobile/issues/aeab31ca301a65d15719466e0974f4bd?time=last-seven-days&types=crash&sessionEventKey=62F5F9B1016C00013804C3DC948805AB_1709327768951433313)

### Reference
- https://stackoverflow.com/a/41813953/10840484
- https://www.androiddesignpatterns.com/2013/08/fragment-transaction-commit-state-loss.html
