### PR TITLE
fix: `CourseUnitNavigationActivity` resume crashes after free up resources.

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
@@ -100,6 +100,7 @@ public abstract class CourseBaseActivity extends BaseFragmentActivity
     }
 
     protected void restore(Bundle savedInstanceState) {
+        blocksApiVersion = config.getApiUrlVersionConfig().getBlocksApiVersion();
         if (savedInstanceState != null) {
             courseData = (EnrolledCoursesResponse) savedInstanceState.getSerializable(Router.EXTRA_COURSE_DATA);
             courseUpgradeData = savedInstanceState.getParcelable(Router.EXTRA_COURSE_UPGRADE_DATA);
@@ -115,7 +116,6 @@ public abstract class CourseBaseActivity extends BaseFragmentActivity
      * Method to force update the course structure from server.
      */
     protected void updateCourseStructure(String courseId, String componentId) {
-        blocksApiVersion = config.getApiUrlVersionConfig().getBlocksApiVersion();
         getHierarchyCall = courseApi.getCourseStructureWithoutStale(blocksApiVersion, courseId);
         getHierarchyCall.enqueue(new CourseAPI.GetCourseStructureCallback(this, courseId,
                 new ProgressViewController(binding.loadingIndicator.loadingIndicator), errorNotification,


### PR DESCRIPTION
### Description

[LEARNER-8984](https://2u-internal.atlassian.net/browse/LEARNER-8984)
[LEARNER-8985](https://2u-internal.atlassian.net/browse/LEARNER-8985)

- App crashes when the user resumes the app when memory is low and the user tries to change the unit/component through the next/previous buttons or swipe left/right, to fix these issues store state using `onSaveInstanceState`, and restore.

### How to test
- Open course component of any course.
- Press the Home button to move the app to the background.
- Fill in both the mobile memories (internal memory and external memory) until OS freed up the app resource. (can use third-party apps.)
- Resume the app will see the black screen.
- Change the course component through next/previous (will reproduce LEARNER-8985) button OR swipe left/right (will reproduce LEARNER-8984). The app will crash.