### PR TITLE
fix: My Courses screen detached fragment issue for ViewModel

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.kt
@@ -160,7 +160,7 @@ class MyCoursesListFragment : OfflineSupportBaseFragment(), RefreshListener {
     }
 
     private fun initInAppPurchaseSetup() {
-        if (environment.remoteFeaturePrefs.isValuePropEnabled()) {
+        if (isAdded && environment.remoteFeaturePrefs.isValuePropEnabled()) {
             initFullscreenLoader()
             initObservers()
         }


### PR DESCRIPTION
### Description

[LEARNER-8986](https://2u-internal.atlassian.net/browse/LEARNER-8986)

App crashes when the learner receives a delayed response from Firebase Remote Config on a detached `MyCourseListFragment` and tries to initialize the viewModel on it. We will restrict the app from initializing ViewModel on a detached fragment to fix this issue.