### PR TITLE
chore: add SDN prompt shows whenever a user clicks on the upgrade CTA

### DIFF
--- a/OpenEdXMobile/res/values/iap_strings.xml
+++ b/OpenEdXMobile/res/values/iap_strings.xml
@@ -52,4 +52,9 @@
     <string name="label_refresh_now">Refresh now</string>
     <!-- Label Continue Without Update -->
     <string name="label_continue_without_update">Continue without update</string>
+
+    <!-- Title of the dialog to verify SDN -->
+    <string name="sdn_dialog_title">Lorem ipsum</string>
+    <!-- Message for the dialog to verify SDN -->
+    <string name="sdn_dialog_message">Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</string>
 </resources>

--- a/OpenEdXMobile/res/values/strings_2.xml
+++ b/OpenEdXMobile/res/values/strings_2.xml
@@ -8,6 +8,6 @@
     <string name="label_leaving_the_app">Leaving the app</string>
     <!-- Dialog Alert Message for Open in browser -->
     <string name="leaving_the_app_message">You are now leaving the {platform_name} app and opening a browser.</string>
-    <!-- Toggle to allow downloads using cellular data -->
+    <!-- Alert dialog accept button label -->
     <string name="label_accept">Accept</string>
 </resources>

--- a/OpenEdXMobile/res/values/strings_2.xml
+++ b/OpenEdXMobile/res/values/strings_2.xml
@@ -8,4 +8,6 @@
     <string name="label_leaving_the_app">Leaving the app</string>
     <!-- Dialog Alert Message for Open in browser -->
     <string name="leaving_the_app_message">You are now leaving the {platform_name} app and opening a browser.</string>
+    <!-- Toggle to allow downloads using cellular data -->
+    <string name="label_accept">Accept</string>
 </resources>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
@@ -618,13 +618,14 @@ public interface Analytics {
      * @param componentId Component id of course unit
      * @param elapsedTime time in milliseconds that app took to perform the action(price load, refresh course content)
      * @param error       error that app sending in get help email
-     * @param errorAction action taken on the error dialog
+     * @param actionTaken action taken on the error dialog
      * @param screenName  Screen name on which event is triggered
      */
     void trackInAppPurchasesEvent(@NonNull String eventName, @NonNull String biValue,
-                                  @NonNull String courseId, boolean isSelfPaced, @Nullable String price,
-                                  @Nullable String componentId, long elapsedTime, @Nullable String error,
-                                  @Nullable String errorAction, @NonNull String screenName);
+                                  @NonNull String courseId, boolean isSelfPaced,
+                                  @Nullable String price, @Nullable String componentId,
+                                  long elapsedTime, @Nullable String error,
+                                  @Nullable String actionTaken, @NonNull String screenName);
 
 
     interface Keys {
@@ -900,6 +901,7 @@ public interface Analytics {
         String ACTION_REFRESH = "refresh";
         String ACTION_GET_HELP = "get_help";
         String ACTION_CLOSE = "close";
+        String ACTION_ACCEPT = "accept";
         String IAP_UPGRADE_NOW_CLICKED = "edx.bi.app.payments.upgrade_now.clicked";
         String IAP_COURSE_UPGRADE_SUCCESS = "edx.bi.app.payments.course_upgrade_success";
         String IAP_UNLOCK_UPGRADED_CONTENT_TIME = "edx.bi.app.payments.time_to_unlock_upgraded_content";
@@ -910,6 +912,7 @@ public interface Analytics {
         String IAP_COURSE_UPGRADE_ERROR = "edx.bi.app.payments.course_upgrade_error";
         String IAP_PRICE_LOAD_ERROR = "edx.bi.app.payments.price_load_error";
         String IAP_ERROR_ALERT_ACTION = "edx.bi.app.payments.error_alert_action";
+        String IAP_SDN_PROMPT_ACTION = "edx.bi.app.payments.sdn_prompt_action";
     }
 
     interface Screens {
@@ -1044,6 +1047,8 @@ public interface Analytics {
         String IAP_COURSE_UPGRADE_ERROR = "Payments: Course Upgrade Error";
         String IAP_PRICE_LOAD_ERROR = "Payments: Price Load Error";
         String IAP_ERROR_ALERT_ACTION = "Payments: Error Alert Action";
+        String IAP_SDN_PROMPT_ACTION = "Payments: SDN Prompt Action";
+
         String VALUE_PROP_LEARN_MORE_CLICKED = "Value Prop Learn More Clicked";
         String VALUE_PROP_MODAL_VIEW = "Value Prop Modal View";
         String COURSE_UNIT_LOCKED_CONTENT = "Value Prop Locked Content Clicked";

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/AnalyticsRegistry.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/AnalyticsRegistry.java
@@ -589,10 +589,10 @@ public class AnalyticsRegistry implements Analytics {
                                          @NonNull String courseId, boolean isSelfPaced,
                                          @Nullable String price, @Nullable String componentId,
                                          long elapsedTime, @Nullable String error,
-                                         @Nullable String errorAction, @NonNull String screenName) {
+                                         @Nullable String actionTaken, @NonNull String screenName) {
         for (Analytics service : services) {
             service.trackInAppPurchasesEvent(eventName, biValue, courseId, isSelfPaced, price,
-                    componentId, elapsedTime, error, errorAction, screenName);
+                    componentId, elapsedTime, error, actionTaken, screenName);
         }
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/FirebaseAnalytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/FirebaseAnalytics.java
@@ -821,8 +821,8 @@ public class FirebaseAnalytics implements Analytics {
     public void trackInAppPurchasesEvent(@NonNull String eventName, @NonNull String biValue,
                                          @NonNull String courseId, boolean isSelfPaced,
                                          @Nullable String price, @Nullable String componentId,
-                                         long elapsedTime, @Nullable String error, @Nullable String errorAction,
-                                         @NonNull String screenName) {
+                                         long elapsedTime, @Nullable String error,
+                                         @Nullable String actionTaken, @NonNull String screenName) {
         final FirebaseEvent event = new FirebaseEvent(eventName, biValue);
         event.putCourseId(courseId);
         event.putString(Keys.PACING, isSelfPaced ? Keys.SELF : Keys.INSTRUCTOR);
@@ -839,8 +839,13 @@ public class FirebaseAnalytics implements Analytics {
         if (!TextUtils.isEmpty(error)) {
             event.putString(Keys.ERROR, error);
         }
-        if (!TextUtils.isEmpty(errorAction)) {
-            event.putString(Keys.ERROR_ACTION, errorAction);
+        if (!TextUtils.isEmpty(actionTaken)) {
+            if (Analytics.Values.IAP_SDN_PROMPT_ACTION.equalsIgnoreCase(eventName)) {
+                event.putString(Keys.ACTION, actionTaken);
+            } else {
+                event.putString(Keys.ERROR_ACTION, actionTaken);
+
+            }
         }
         event.putString(Keys.SCREEN_NAME, screenName);
         logFirebaseEvent(event.getName(), event.getBundle());

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/InAppPurchasesAnalytics.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/InAppPurchasesAnalytics.kt
@@ -21,7 +21,7 @@ class InAppPurchasesAnalytics @Inject constructor(
     private var refreshContentTime: Long = 0
     private var upgradeCourseTime: Long = 0
     private var errorMsg: String = ""
-    private var errorAction: String = ""
+    private var actionTaken: String = ""
 
     fun initCourseValues(
         courseId: String,
@@ -108,8 +108,13 @@ class InAppPurchasesAnalytics @Inject constructor(
             }
             Analytics.Events.IAP_ERROR_ALERT_ACTION -> {
                 this.errorMsg = errorMsg
-                this.errorAction = actionTaken
+                this.actionTaken = actionTaken
                 trackEvent(eventName, Analytics.Values.IAP_ERROR_ALERT_ACTION)
+            }
+            Analytics.Events.IAP_SDN_PROMPT_ACTION -> {
+                this.actionTaken = actionTaken
+                trackEvent(eventName, Analytics.Values.IAP_SDN_PROMPT_ACTION)
+                upgradeCourseTime = getCurrentTime()
             }
         }
         resetEventValues()
@@ -118,7 +123,7 @@ class InAppPurchasesAnalytics @Inject constructor(
     private fun resetEventValues() {
         elapsedTime = 0
         errorMsg = ""
-        errorAction = ""
+        actionTaken = ""
     }
 
     private fun resetAnalytics() {
@@ -129,7 +134,7 @@ class InAppPurchasesAnalytics @Inject constructor(
         upgradeCourseTime = 0
         elapsedTime = 0
         errorMsg = ""
-        errorAction = ""
+        actionTaken = ""
     }
 
     private fun trackEvent(eventName: String, biValue: String) =
@@ -142,7 +147,7 @@ class InAppPurchasesAnalytics @Inject constructor(
             componentId,
             elapsedTime,
             errorMsg,
-            errorAction,
+            actionTaken,
             screenName
         )
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/SegmentAnalytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/SegmentAnalytics.java
@@ -1110,8 +1110,8 @@ public class SegmentAnalytics implements Analytics {
     public void trackInAppPurchasesEvent(@NonNull String eventName, @NonNull String biValue,
                                          @NonNull String courseId, boolean isSelfPaced,
                                          @Nullable String price, @Nullable String componentId,
-                                         long elapsedTime, @Nullable String error, @Nullable String errorAction,
-                                         @NonNull String screenName) {
+                                         long elapsedTime, @Nullable String error,
+                                         @Nullable String actionTaken, @NonNull String screenName) {
         final SegmentEvent aEvent = new SegmentEvent();
         aEvent.properties.putValue(Keys.NAME, biValue);
         aEvent.properties.putValue(Keys.CATEGORY, Values.IN_APP_PURCHASES);
@@ -1129,8 +1129,12 @@ public class SegmentAnalytics implements Analytics {
         if (!TextUtils.isEmpty(error)) {
             aEvent.data.putValue(Keys.ERROR, error);
         }
-        if (!TextUtils.isEmpty(errorAction)) {
-            aEvent.data.putValue(Keys.ERROR_ACTION, errorAction);
+        if (!TextUtils.isEmpty(actionTaken)) {
+            if (Analytics.Values.IAP_SDN_PROMPT_ACTION.equals(biValue)) {
+                aEvent.data.putValue(Keys.ACTION, actionTaken);
+            } else {
+                aEvent.data.putValue(Keys.ERROR_ACTION, actionTaken);
+            }
         }
         aEvent.data.putValue(Keys.SCREEN_NAME, screenName);
         trackSegmentEvent(eventName, aEvent.properties);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/InAppPurchasesUtils.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/InAppPurchasesUtils.kt
@@ -193,4 +193,27 @@ class InAppPurchasesUtils @Inject constructor(
             actionTaken = Values.ACTION_GET_HELP
         )
     }
+
+    fun showSDNDialog(fragment: Fragment, onPositiveClick: DialogInterface.OnClickListener) {
+        AlertDialogFragment.newInstance(
+            fragment.getString(R.string.sdn_dialog_title),
+            fragment.getString(R.string.sdn_dialog_message),
+            fragment.getString(R.string.label_accept),
+            { dialog, which ->
+                onPositiveClick.onClick(dialog, which)
+                iapAnalytics.trackIAPEvent(
+                    eventName = Events.IAP_SDN_PROMPT_ACTION,
+                    actionTaken = Values.ACTION_ACCEPT
+                )
+            },
+            fragment.getString(R.string.label_cancel),
+            { _, _ ->
+                iapAnalytics.trackIAPEvent(
+                    eventName = Events.IAP_SDN_PROMPT_ACTION,
+                    actionTaken = Values.ACTION_CANCEL
+                )
+            },
+            false
+        ).show(fragment.childFragmentManager, null)
+    }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.kt
@@ -24,7 +24,12 @@ import org.edx.mobile.model.course.CourseComponent
 import org.edx.mobile.module.analytics.Analytics.Events
 import org.edx.mobile.module.analytics.Analytics.Screens
 import org.edx.mobile.module.analytics.InAppPurchasesAnalytics
-import org.edx.mobile.util.*
+import org.edx.mobile.util.AppConstants
+import org.edx.mobile.util.BrowserUtil
+import org.edx.mobile.util.InAppPurchasesException
+import org.edx.mobile.util.InAppPurchasesUtils
+import org.edx.mobile.util.NonNullObserver
+import org.edx.mobile.util.ResourceUtil
 import org.edx.mobile.viewModel.InAppPurchasesViewModel
 import javax.inject.Inject
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.kt
@@ -24,12 +24,7 @@ import org.edx.mobile.model.course.CourseComponent
 import org.edx.mobile.module.analytics.Analytics.Events
 import org.edx.mobile.module.analytics.Analytics.Screens
 import org.edx.mobile.module.analytics.InAppPurchasesAnalytics
-import org.edx.mobile.util.AppConstants
-import org.edx.mobile.util.BrowserUtil
-import org.edx.mobile.util.InAppPurchasesException
-import org.edx.mobile.util.InAppPurchasesUtils
-import org.edx.mobile.util.NonNullObserver
-import org.edx.mobile.util.ResourceUtil
+import org.edx.mobile.util.*
 import org.edx.mobile.viewModel.InAppPurchasesViewModel
 import javax.inject.Inject
 
@@ -131,9 +126,11 @@ class CourseUnitMobileNotSupportedFragment : CourseUnitFragment() {
             binding.layoutUpgradeBtn.root.setVisibility(true)
             binding.layoutUpgradeBtn.btnUpgrade.setOnClickListener {
                 iapAnalytics.trackIAPEvent(Events.IAP_UPGRADE_NOW_CLICKED)
-                unit?.courseSku?.let { productId ->
-                    iapViewModel.addProductToBasket(productId)
-                } ?: iapUtils.showUpgradeErrorDialog(this)
+                iapUtils.showSDNDialog(this) { _, _ ->
+                    unit?.courseSku?.let { productId ->
+                        iapViewModel.addProductToBasket(productId)
+                    } ?: iapUtils.showUpgradeErrorDialog(this)
+                }
             }
 
             billingProcessor = BillingProcessor(requireContext(), object : BillingFlowListeners {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
@@ -20,7 +20,11 @@ import org.edx.mobile.http.HttpStatus
 import org.edx.mobile.inapppurchases.BillingProcessor
 import org.edx.mobile.module.analytics.Analytics.Events
 import org.edx.mobile.module.analytics.InAppPurchasesAnalytics
-import org.edx.mobile.util.*
+import org.edx.mobile.util.AppConstants
+import org.edx.mobile.util.InAppPurchasesException
+import org.edx.mobile.util.InAppPurchasesUtils
+import org.edx.mobile.util.NonNullObserver
+import org.edx.mobile.util.ResourceUtil
 import org.edx.mobile.viewModel.InAppPurchasesViewModel
 import javax.inject.Inject
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
@@ -20,11 +20,7 @@ import org.edx.mobile.http.HttpStatus
 import org.edx.mobile.inapppurchases.BillingProcessor
 import org.edx.mobile.module.analytics.Analytics.Events
 import org.edx.mobile.module.analytics.InAppPurchasesAnalytics
-import org.edx.mobile.util.AppConstants
-import org.edx.mobile.util.InAppPurchasesException
-import org.edx.mobile.util.InAppPurchasesUtils
-import org.edx.mobile.util.NonNullObserver
-import org.edx.mobile.util.ResourceUtil
+import org.edx.mobile.util.*
 import org.edx.mobile.viewModel.InAppPurchasesViewModel
 import javax.inject.Inject
 
@@ -112,9 +108,11 @@ class CourseModalDialogFragment : DialogFragment() {
 
         binding.layoutUpgradeBtn.btnUpgrade.setOnClickListener {
             iapAnalytics.trackIAPEvent(eventName = Events.IAP_UPGRADE_NOW_CLICKED)
-            courseSku?.let {
-                iapViewModel.addProductToBasket(it)
-            } ?: iapUtils.showUpgradeErrorDialog(this)
+            iapUtils.showSDNDialog(this) { _, _ ->
+                courseSku?.let {
+                    iapViewModel.addProductToBasket(it)
+                } ?: iapUtils.showUpgradeErrorDialog(this)
+            }
         }
         billingProcessor =
             BillingProcessor(requireContext(), object : BillingProcessor.BillingFlowListeners {


### PR DESCRIPTION
### Description

[LEARNER-8993](https://2u-internal.atlassian.net/browse/LEARNER-8993)

**Pre-Purchase**
Add a prompt after the user taps the ‘Upgrade’ button that informs the user of their personal data being used to verify SDN. Prompt copy TBD. 
- If the user opts-in, continue to the normal check-out flow.
- If the user does not opt-in, cancel the checkout and direct the user to the previous screen.
- Add Analytics for SDN accept or cancel

### Acceptance Criteria

- [x] SDN prompt shows whenever a user clicks on the upgrade CTA.
- [x] Prompt CTAs Cancel and Accept.
- [x] Tapping Accept will allow the user to continue forward in the purchase flow.
- [x] Tapping Cancel will take the user back to the Value Prompt.
- [x] User must accept the SDN prompt to make a purchase.

**Notes**
The title and message of the SDN prompt aren't finalized yet.
