### PR TITLE
chore: Allow users to purchase course on treatment/control group

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/AppFeaturesPrefs.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/AppFeaturesPrefs.kt
@@ -20,4 +20,25 @@ class AppFeaturesPrefs @Inject constructor(@ApplicationContext context: Context)
     private fun getAppConfig(): AppConfig {
         return Gson().fromJson(pref.getString(PrefManager.Key.APP_CONFIG), AppConfig::class.java)
     }
+
+    private fun getIAPConfig() = getAppConfig().iapConfig
+
+    fun isIAPEnabled() = getIAPConfig().isEnabled
+
+    /**
+     * Method to check if the IAP is enabled for treatment/control group
+     * Any user with odd user Id falls under treatment group and
+     * user with even id falls under control group
+     * The App will allow the user to purchase the course only if [org.edx.mobile.model.api.IAPConfig.isEnabled] is true
+     * If [org.edx.mobile.model.api.IAPConfig.isExperimentEnabled] is true then only treatment group will be able to buy the course.
+     */
+    fun isIAPEnabled(isOddUserId: Boolean): Boolean {
+        if (isIAPEnabled()) {
+            if (getIAPConfig().isExperimentEnabled) {
+                return isOddUserId
+            }
+            return true
+        }
+        return false
+    }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
@@ -169,6 +169,10 @@ public class LoginPrefs {
         return profileModel != null ? profileModel.id : null;
     }
 
+    public boolean isOddUserId() {
+        return (getUserId() != null && getUserId() % 2 == 1);
+    }
+
     @Nullable
     public String getUsername() {
         final ProfileModel profileModel = getCurrentUserProfile();

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/Config.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/Config.java
@@ -79,7 +79,6 @@ public class Config {
     private static final String DISCUSSIONS_ENABLE_PROFILE_PICTURE_PARAM = "DISCUSSIONS_ENABLE_PROFILE_PICTURE_PARAM";
     private static final String REGISTRATION_ENABLED = "REGISTRATION_ENABLED";
     private static final String APP_REVIEWS_ENABLED = "APP_REVIEWS_ENABLED";
-    private static final String IAP_ENABLED = "IAP_ENABLED";
     private static final String VIDEO_TRANSCRIPT_ENABLED = "VIDEO_TRANSCRIPT_ENABLED";
     private static final String USING_VIDEO_PIPELINE = "USING_VIDEO_PIPELINE";
     private static final String COURSE_DATES_ENABLED = "COURSE_DATES_ENABLED";
@@ -652,10 +651,6 @@ public class Config {
 
     public boolean isAppReviewsEnabled() {
         return getBoolean(APP_REVIEWS_ENABLED, false);
-    }
-
-    public boolean isIAPEnabled() {
-        return getBoolean(IAP_ENABLED, false);
     }
 
     public boolean areCertificateLinksEnabled() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/AccountFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/AccountFragment.kt
@@ -99,7 +99,7 @@ class AccountFragment : BaseFragment() {
         updateSDCardSwitch()
         initHelpFields()
 
-        binding.containerPurchases.setVisibility(environment.config.isIAPEnabled)
+        binding.containerPurchases.setVisibility(environment.appFeaturesPrefs.isIAPEnabled())
         if (!loginPrefs.username.isNullOrBlank()) {
             binding.btnSignOut.visibility = View.VISIBLE
             binding.btnSignOut.setOnClickListener {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.kt
@@ -118,7 +118,7 @@ class CourseUnitMobileNotSupportedFragment : CourseUnitFragment() {
     }
 
     private fun setUpUpgradeButton(isSelfPaced: Boolean) {
-        if (environment.config.isIAPEnabled) {
+        if (environment.appFeaturesPrefs.isIAPEnabled(environment.loginPrefs.isOddUserId)) {
             unit?.let {
                 iapAnalytics.initCourseValues(
                     courseId = it.courseId,

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
@@ -36,6 +36,7 @@ class CourseModalDialogFragment : DialogFragment() {
     private var courseId: String = ""
     private var courseSku: String? = null
     private var isSelfPaced: Boolean = false
+    private var isPurchaseEnabled: Boolean = false
 
     private var billingProcessor: BillingProcessor? = null
 
@@ -74,8 +75,10 @@ class CourseModalDialogFragment : DialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        isPurchaseEnabled =
+            environment.appFeaturesPrefs.isIAPEnabled(environment.loginPrefs.isOddUserId)
         initViews()
-        if (environment.config.isIAPEnabled) {
+        if (isPurchaseEnabled) {
             initBillingProcessor()
         }
     }
@@ -101,7 +104,7 @@ class CourseModalDialogFragment : DialogFragment() {
             KEY_COURSE_NAME,
             arguments?.getString(KEY_COURSE_NAME)
         )
-        binding.layoutUpgradeBtn.root.setVisibility(environment.config.isIAPEnabled)
+        binding.layoutUpgradeBtn.root.setVisibility(isPurchaseEnabled)
         binding.dialogDismiss.setOnClickListener {
             dialog?.dismiss()
         }


### PR DESCRIPTION
### Description

[LEARNER-9026](https://2u-internal.atlassian.net/browse/LEARNER-9026)

This PR moves the IAP config from [Config](https://github.com/edx/edx-mobile-config) to AppConfig.
The config is available using enrolments API v1.5 which is currently available on the IAP sandbox

`API: api/mobile/{api_version}/users/{username}/course_enrollments/`

- Migrate IAPConfig from Config.java to Django Admin
- Add Data model for IAPConfig
- Differentiate users on UserID
- Allow purchases to only treatment groups if the experiment is enabled otherwise anyone can purchase.