### PR TITLE
fix: Youtube and Native Video Player Glitches on Configuration Change

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/player/PlayerFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/player/PlayerFragment.java
@@ -764,12 +764,6 @@ public class PlayerFragment extends BaseFragment implements IPlayerListener, Ser
         // mark prepared and allow orientation
         isPrepared = true;
 
-        if (getActivity() == null) {
-            return;
-        }
-
-        allowSensorOrientation();
-
         if (!isResumed() || !getUserVisibleHint() || isCastingOnRemoteDevice()) {
             freezePlayer();
             hideProgress();

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitYoutubePlayerFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitYoutubePlayerFragment.java
@@ -20,6 +20,7 @@ import org.edx.mobile.module.analytics.Analytics;
 import org.edx.mobile.module.db.impl.DatabaseFactory;
 import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.BrowserUtil;
+import org.edx.mobile.util.DeviceSettingUtil;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.util.VideoUtil;
 import org.greenrobot.eventbus.EventBus;
@@ -123,7 +124,9 @@ public class CourseUnitYoutubePlayerFragment extends BaseCourseUnitVideoFragment
          */
         if (youTubePlayer != null) {
             try {
-                youTubePlayer.setFullscreen(fullscreen);
+                if (DeviceSettingUtil.isDeviceRotationON(getActivity())) {
+                    youTubePlayer.setFullscreen(fullscreen);
+                }
             } catch (IllegalStateException e) {
                 logger.error(e);
                 releaseYoutubePlayer();
@@ -321,13 +324,10 @@ public class CourseUnitYoutubePlayerFragment extends BaseCourseUnitVideoFragment
     private class FullscreenListener implements YouTubePlayer.OnFullscreenListener {
         @Override
         public void onFullscreen(boolean fullScreen) {
-            final int orientation = getResources().getConfiguration().orientation;
             if (getActivity() != null) {
-                if (!fullScreen && orientation == Configuration.ORIENTATION_LANDSCAPE) {
-                    getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
-                } else {
-                    getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
-                }
+                getActivity().setRequestedOrientation(fullScreen ?
+                        ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE :
+                        ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
             }
             if (videoModel != null) {
                 environment.getAnalyticsRegistry().trackVideoOrientation(videoModel.videoId,


### PR DESCRIPTION
### Description

[LEARNER-7729](https://2u-internal.atlassian.net/browse/LEARNER-7729) | [LEARNER-9004](https://2u-internal.atlassian.net/browse/LEARNER-9004)

- YoutubePlayer handles configuration changes on its own via the default `FULLSCREEN_FLAG_CONTROL_ORIENTATION` control flag. This default behavior conflicted with the base class' configuration change listeners and was causing orientation glitches. ([LEARNER-7729](https://2u-internal.atlassian.net/browse/LEARNER-7729))

- Native Video Player enabled screen orientation sensor for the activity during locked orientation mode on the device which later caused glitches while starting the video. ([LEARNER-9004](https://2u-internal.atlassian.net/browse/LEARNER-9004))
