### PR TITLE
feat: Logout disabled learners

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/authenticator/OauthRefreshTokenAuthenticator.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/authenticator/OauthRefreshTokenAuthenticator.kt
@@ -103,7 +103,10 @@ class OauthRefreshTokenAuthenticator @Inject constructor(
                  */
                 EventBus.getDefault().post(LogoutEvent())
             }
-            DISABLED_USER_ERROR_MESSAGE -> EventBus.getDefault().post(LogoutEvent())
+            DISABLED_USER_ERROR_MESSAGE,
+            JWT_DISABLED_USER_ERROR_MESSAGE -> {
+                EventBus.getDefault().post(LogoutEvent())
+            }
         }
 
         /**
@@ -234,6 +237,7 @@ class OauthRefreshTokenAuthenticator @Inject constructor(
         private const val TOKEN_NONEXISTENT_ERROR_MESSAGE = "token_nonexistent"
         private const val TOKEN_INVALID_GRANT_ERROR_MESSAGE = "invalid_grant"
         private const val DISABLED_USER_ERROR_MESSAGE = "user_is_disabled"
+        private const val JWT_DISABLED_USER_ERROR_MESSAGE = "User account is disabled."
         private const val JWT_TOKEN_EXPIRED = "Token has expired."
         private const val JWT_INVALID_TOKEN = "Invalid token."
 


### PR DESCRIPTION
### Description

[LEARNER-8997](https://2u-internal.atlassian.net/browse/LEARNER-8997)

Logout disabled user on receiving the following response on `oauth2/login/` network request

```
URL: https://courses.edx.org/oauth2/login/
status_code: 401
{
  "error_code": "account_disabled",
  "developer_message": "User account is disabled."
}
```

### How to test this PR

- Sign in with a valid user
- Disabled the user from the support tool
- Rerun the app and see the response of `/oauth2/login/`
