### PR TITLE
feat: Reuse unfulfilled purchases code for Restore Purchase Flow

### DIFF
--- a/OpenEdXMobile/res/layout/fragment_account.xml
+++ b/OpenEdXMobile/res/layout/fragment_account.xml
@@ -216,6 +216,14 @@
                     style="@style/profile_field_description"
                     android:text="@string/description_purchase" />
 
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/btn_restore_purchases"
+                    style="@style/edX.Widget.ProfileActionBorderedButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/profile_view_button_height"
+                    android:layout_marginTop="@dimen/edx_half_margin"
+                    android:text="@string/title_purchase" />
+
                 <View
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/edx_line"
@@ -258,7 +266,6 @@
                     android:id="@+id/btn_email_support"
                     style="@style/edX.Widget.ProfileActionBorderedButton"
                     android:layout_marginTop="@dimen/edx_half_margin"
-                    android:focusable="true"
                     android:text="@string/label_submit_feedback_btn" />
             </LinearLayout>
 

--- a/OpenEdXMobile/res/values/iap_strings.xml
+++ b/OpenEdXMobile/res/values/iap_strings.xml
@@ -52,4 +52,10 @@
     <string name="label_refresh_now">Refresh now</string>
     <!-- Label Continue Without Update -->
     <string name="label_continue_without_update">Continue without update</string>
+    <!-- Title of the dialog to while verifying the incomplete purchases -->
+    <string name="title_checking_purchases">Checking purchases\.\.\.</string>
+    <!-- Title of the Purchases successfully restored dialog -->
+    <string name="title_purchases_restored">Purchases have been successfully restored</string>
+    <!-- Message for the Purchases successfully restored dialog -->
+    <string name="message_purchases_restored">All purchases are up to date. If you’re not seeing your purchases restored, please try restarting your app to refresh the experience.</string>
 </resources>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/exception/ErrorMessage.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/exception/ErrorMessage.kt
@@ -1,18 +1,18 @@
 package org.edx.mobile.exception
 
-import androidx.annotation.StringRes
+import org.edx.mobile.http.HttpStatusException
+import org.edx.mobile.util.InAppPurchasesException
 
 /**
  * Error handling model class for ViewModel
- * handle exceptions/error based on errorCode
+ * handle exceptions/error based on requestType
  */
 data class ErrorMessage(
-    val errorCode: Int,
-    val throwable: Throwable,
-    @StringRes val errorResId: Int = 0
+    val requestType: Int = 0,
+    val throwable: Throwable
 ) {
     companion object {
-        // Custom error codes
+        // Custom Codes for request types
         const val BANNER_INFO_CODE = 101
         const val COURSE_RESET_DATES_CODE = 102
         const val COURSE_DATES_CODE = 103
@@ -23,5 +23,25 @@ data class ErrorMessage(
         const val PAYMENT_SDK_CODE = 0x204
         const val COURSE_REFRESH_CODE = 0x205
         const val PRICE_CODE = 0x206
+    }
+
+    fun getHttpErrorCode(): Int {
+        if (throwable is InAppPurchasesException) {
+            return throwable.httpErrorCode
+        } else if (throwable is HttpStatusException) {
+            return throwable.statusCode
+        }
+        return -1
+    }
+
+    fun getErrorMessage(): String? {
+        if (throwable is InAppPurchasesException) {
+            return throwable.errorMessage
+        }
+        return throwable.message
+    }
+
+    fun canRetry(): Boolean {
+        return requestType == PRICE_CODE
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/ResponseExt.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/ResponseExt.kt
@@ -9,7 +9,7 @@ import retrofit2.Response
 /**
  * Transforms [Response] to [Result] object for In-App Purchases success or error scenarios
  */
-fun <T> Response<T>.toInAppPurchasesResult(callback: NetworkResponseCallback<T>, apiCode: Int) {
+fun <T> Response<T>.toInAppPurchasesResult(callback: NetworkResponseCallback<T>) {
     when (isSuccessful && body() != null) {
         true -> callback.onSuccess(
             Result.Success(
@@ -22,7 +22,6 @@ fun <T> Response<T>.toInAppPurchasesResult(callback: NetworkResponseCallback<T>,
         false -> callback.onError(
             Result.Error(
                 InAppPurchasesException(
-                    errorCode = apiCode,
                     httpErrorCode = code(),
                     errorMessage = getMessage(),
                 )

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/EnrollmentResponse.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/EnrollmentResponse.kt
@@ -1,14 +1,10 @@
 package org.edx.mobile.model.api
 
-import com.google.gson.Gson
-import com.google.gson.JsonArray
-import com.google.gson.JsonDeserializationContext
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonElement
-import com.google.gson.JsonObject
+import com.google.gson.*
 import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
 import org.edx.mobile.logger.Logger
+import org.edx.mobile.model.course.EnrollmentMode
 import java.io.Serializable
 import java.lang.reflect.Type
 
@@ -66,4 +62,14 @@ data class EnrollmentResponse(
             }
         }
     }
+}
+
+/**
+ * Method to filter the audit course Skus from the given enrolled course list.
+ *
+ * @return the list of all audit courses SKUs.
+ */
+fun List<EnrolledCoursesResponse>.getAuditCoursesSku(): List<String> {
+    return this.filter { EnrollmentMode.AUDIT.toString().equals(it.mode, true) }
+        .mapNotNull { it.courseSku }.toList()
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
@@ -489,7 +489,7 @@ public interface Analytics {
      * @param showMore    True when user tapped on show more otherwise false
      */
     void trackValuePropShowMoreLessClicked(@NonNull String courseId, @Nullable String componentId,
-                                           @NonNull String price, boolean isSelfPaced, boolean showMore);
+                                           @Nullable String price, boolean isSelfPaced, boolean showMore);
 
     /**
      * Tracks explore all courses tapped on landing screen.

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/AnalyticsRegistry.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/AnalyticsRegistry.java
@@ -476,7 +476,7 @@ public class AnalyticsRegistry implements Analytics {
 
     @Override
     public void trackValuePropShowMoreLessClicked(@NonNull String courseId, @Nullable String componentId,
-                                                  @NonNull String price, boolean isSelfPaced, boolean showMore) {
+                                                  @Nullable String price, boolean isSelfPaced, boolean showMore) {
         for (Analytics service : services) {
             service.trackValuePropShowMoreLessClicked(courseId, componentId, price, isSelfPaced, showMore);
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/FirebaseAnalytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/FirebaseAnalytics.java
@@ -677,11 +677,13 @@ public class FirebaseAnalytics implements Analytics {
 
     @Override
     public void trackValuePropShowMoreLessClicked(@NonNull String courseId, @Nullable String componentId,
-                                                  @NonNull String price, boolean isSelfPaced, boolean showMore) {
+                                                  @Nullable String price, boolean isSelfPaced, boolean showMore) {
         final FirebaseEvent event = new FirebaseEvent(showMore ? Events.VALUE_PROP_SHOW_MORE_CLICKED : Events.VALUE_PROP_SHOW_LESS_CLICKED,
                 showMore ? Values.VALUE_PROP_SHOW_MORE_CLICKED : Values.VALUE_PROP_SHOW_LESS_CLICKED);
         event.putCourseId(courseId);
-        event.putString(Keys.PRICE, price);
+        if (!TextUtils.isEmpty(price)) {
+            event.putString(Keys.PRICE, price);
+        }
         if (!TextUtils.isEmpty(componentId)) {
             event.putString(Keys.COMPONENT_ID, componentId);
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/SegmentAnalytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/SegmentAnalytics.java
@@ -958,11 +958,13 @@ public class SegmentAnalytics implements Analytics {
 
     @Override
     public void trackValuePropShowMoreLessClicked(@NonNull String courseId, @Nullable String componentId,
-                                                  @NonNull String price, boolean isSelfPaced, boolean showMore) {
+                                                  @Nullable String price, boolean isSelfPaced, boolean showMore) {
         final SegmentEvent aEvent = new SegmentEvent();
         aEvent.properties.putValue(Keys.NAME, showMore ? Values.VALUE_PROP_SHOW_MORE_CLICKED : Values.VALUE_PROP_SHOW_LESS_CLICKED);
         aEvent.data.putValue(Keys.COURSE_ID, courseId);
-        aEvent.data.putValue(Keys.PRICE, price);
+        if (!TextUtils.isEmpty(price)) {
+            aEvent.data.putValue(Keys.PRICE, price);
+        }
         if (!TextUtils.isEmpty(componentId)) {
             aEvent.data.putValue(Keys.COMPONENT_ID, componentId);
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/repository/InAppPurchasesRepository.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/repository/InAppPurchasesRepository.kt
@@ -1,6 +1,5 @@
 package org.edx.mobile.repository
 
-import org.edx.mobile.exception.ErrorMessage
 import org.edx.mobile.extenstion.toInAppPurchasesResult
 import org.edx.mobile.http.model.NetworkResponseCallback
 import org.edx.mobile.http.model.Result
@@ -20,7 +19,7 @@ class InAppPurchasesRepository(private var iapAPI: InAppPurchasesAPI) {
                 call: Call<AddToBasketResponse>,
                 response: Response<AddToBasketResponse>
             ) {
-                response.toInAppPurchasesResult(callback, ErrorMessage.ADD_TO_BASKET_CODE)
+                response.toInAppPurchasesResult(callback)
             }
 
             override fun onFailure(call: Call<AddToBasketResponse>, t: Throwable) {
@@ -35,7 +34,7 @@ class InAppPurchasesRepository(private var iapAPI: InAppPurchasesAPI) {
                 call: Call<CheckoutResponse>,
                 response: Response<CheckoutResponse>
             ) {
-                response.toInAppPurchasesResult(callback, ErrorMessage.CHECKOUT_CODE)
+                response.toInAppPurchasesResult(callback)
             }
 
             override fun onFailure(call: Call<CheckoutResponse>, t: Throwable) {
@@ -59,7 +58,7 @@ class InAppPurchasesRepository(private var iapAPI: InAppPurchasesAPI) {
                 call: Call<ExecuteOrderResponse>,
                 response: Response<ExecuteOrderResponse>
             ) {
-                response.toInAppPurchasesResult(callback, ErrorMessage.EXECUTE_ORDER_CODE)
+                response.toInAppPurchasesResult(callback)
             }
 
             override fun onFailure(call: Call<ExecuteOrderResponse>, t: Throwable) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/InAppPurchasesException.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/InAppPurchasesException.kt
@@ -1,7 +1,14 @@
 package org.edx.mobile.util
 
-class InAppPurchasesException(
-    val errorCode: Int,
-    val httpErrorCode: Int,
-    val errorMessage: String?
-) : Exception(errorMessage)
+/**
+ *
+ * Signals that the user unable to complete the in-app purchases follow it being not parsable or
+ * incomplete according to what we expect.
+ *
+ * @param httpErrorCode stores the error codes can be either [BillingClient][com.android.billingclient.api.BillingClient]
+ *                      OR http error codes for ecommerce end-points, and setting it up to `-1`
+ *                      cause some at some service return error code `0`.
+ * @param errorMessage stores the error messages received from BillingClient & ecommerce end-points.
+ * */
+class InAppPurchasesException(val httpErrorCode: Int = -1, val errorMessage: String? = null) :
+    Exception(errorMessage)

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/InAppPurchasesUtils.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/InAppPurchasesUtils.kt
@@ -1,196 +1,50 @@
 package org.edx.mobile.util
 
-import android.content.DialogInterface
-import androidx.annotation.StringRes
-import androidx.fragment.app.DialogFragment
-import androidx.fragment.app.Fragment
 import org.edx.mobile.R
-import org.edx.mobile.core.IEdxEnvironment
 import org.edx.mobile.exception.ErrorMessage
-import org.edx.mobile.http.HttpStatus
-import org.edx.mobile.module.analytics.Analytics.Events
-import org.edx.mobile.module.analytics.Analytics.Values
-import org.edx.mobile.module.analytics.InAppPurchasesAnalytics
-import org.edx.mobile.view.dialog.AlertDialogFragment
-import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
-class InAppPurchasesUtils @Inject constructor(
-    var environment: IEdxEnvironment,
-    var iapAnalytics: InAppPurchasesAnalytics,
-) {
+object InAppPurchasesUtils {
+
+    val postPurchasedRequests =
+        listOf(ErrorMessage.EXECUTE_ORDER_CODE, ErrorMessage.COURSE_REFRESH_CODE)
 
     /**
-     * Shows Alert Dialog for all error cases that can occur before a successful course purchase i.e
-     * SKU/Product ID not available (Enrollment-API), while fetching the price from Play Console
-     * (Payment SDK), Adding course in purchase basket/cart (Basket-API), during basket checkout
-     * (Checkout-API) or while purchasing a course (Payment SDK).
-     *
-     * All Alerts (except Price Fetching): Two buttons; Cancel and Get help, without any listener
-     * Fetching Price Alert: Two buttons; Try again & Cancel, with a listener for Try again
-     *
-     * Events are also tracked on interaction with the alert.
-     *
-     * @param context Fragment context for resolving message strings and displaying the dialog
-     * @param errorResId Reference to the localized string resource for message
-     * @param errorCode Http Status Code for feedback message
-     * @param errorMessage API error response for feedback message
-     * @param errorType IAP [ErrorMessage] type/code for feedback message
-     * @param listener Retry listener to fetch the course price again
-     */
-    fun showUpgradeErrorDialog(
-        context: Fragment,
-        @StringRes errorResId: Int = R.string.general_error_message,
-        errorCode: Int? = null,
-        errorMessage: String? = null,
-        errorType: Int? = null,
-        listener: DialogInterface.OnClickListener? = null
-    ) {
-        // To restrict showing error dialog on an unattached fragment
-        if (!context.isAdded) return
+     * Method to filter the incomplete purchases for the given enrolled audit course and already paid
+     * through google play store.
+     * */
+    fun getInCompletePurchases(
+        auditCoursesSku: List<String>,
+        purchases: List<Pair<String, String>>
+    ): MutableList<Pair<String, String>> {
+        return purchases.filter { it.first in auditCoursesSku }.toMutableList()
+    }
 
-        val feedbackErrorMessage: String = TextUtils.getFormattedErrorMessage(
-            errorCode,
-            errorType,
-            errorMessage
-        ).toString()
-
-        when (errorType) {
-            ErrorMessage.PAYMENT_SDK_CODE -> iapAnalytics.trackIAPEvent(
-                eventName = Events.IAP_PAYMENT_ERROR,
-                errorMsg = feedbackErrorMessage
-            )
-            ErrorMessage.PRICE_CODE -> iapAnalytics.trackIAPEvent(
-                eventName = Events.IAP_PRICE_LOAD_ERROR,
-                errorMsg = feedbackErrorMessage
-            )
-            else -> iapAnalytics.trackIAPEvent(
-                eventName = Events.IAP_COURSE_UPGRADE_ERROR,
-                errorMsg = feedbackErrorMessage
-            )
+    /**
+     * Method to get the error message resource id based given request type and http error code.
+     *
+     * @param requestType request type for error message resource id from [org.edx.mobile.exception.ErrorMessage].
+     * @param httpErrorCode http error code singled from the BillingClient OR ecommerce end-points.
+     *
+     * @return error message resource id.
+     * */
+    fun getErrorMessage(requestType: Int, httpErrorCode: Int) =
+        when (httpErrorCode) {
+            400 -> when (requestType) {
+                ErrorMessage.ADD_TO_BASKET_CODE -> R.string.error_course_not_found
+                ErrorMessage.CHECKOUT_CODE -> R.string.error_payment_not_processed
+                ErrorMessage.EXECUTE_ORDER_CODE -> R.string.error_course_not_fullfilled
+                else -> R.string.general_error_message
+            }
+            403 -> when (requestType) {
+                ErrorMessage.EXECUTE_ORDER_CODE -> R.string.error_course_not_fullfilled
+                else -> R.string.error_user_not_authenticated
+            }
+            406 -> R.string.error_course_already_paid
+            else -> when (requestType) {
+                ErrorMessage.PAYMENT_SDK_CODE -> R.string.error_payment_not_processed
+                ErrorMessage.PRICE_CODE -> R.string.error_price_not_fetched
+                ErrorMessage.COURSE_REFRESH_CODE -> R.string.error_course_not_fullfilled
+                else -> R.string.general_error_message
+            }
         }
-
-        AlertDialogFragment.newInstance(
-            context.getString(R.string.title_upgrade_error),
-            context.getString(errorResId),
-            context.getString(if (listener != null) R.string.try_again else R.string.label_close),
-            { dialog, which ->
-                listener?.onClick(dialog, which).also {
-                    iapAnalytics.trackIAPEvent(
-                        eventName = Events.IAP_ERROR_ALERT_ACTION,
-                        errorMsg = feedbackErrorMessage,
-                        actionTaken = Values.ACTION_RELOAD_PRICE
-                    )
-                } ?: run { trackAlertCloseEvent(feedbackErrorMessage) }
-            },
-            context.getString(if (listener != null) R.string.label_cancel else R.string.label_get_help),
-            { _, _ ->
-                if (listener != null) {
-                    trackAlertCloseEvent(feedbackErrorMessage)
-                    if (context is DialogFragment) context.dismiss()
-                } else {
-                    showFeedbackScreen(context, feedbackErrorMessage)
-                }
-            }, false
-        ).show(context.childFragmentManager, null)
-    }
-
-    /**
-     * Shows Alert Dialog for all error cases that can occur after a successful course purchase i.e
-     * Course already purchased (Basket-API) or unable to verify the purchase on backend
-     * (Execute-API).
-     *
-     * Course Already Purchased : Three buttons; Refresh Now, Get help and Cancel, with two
-     * listeners. One for refresh and the other one for Get help and Cancel
-     * Unable to Verify: Three buttons; Refresh to retry, Get help and Cancel, with two listeners.
-     * One for Refresh to retry and the other one for Get Help and Cancel
-     *
-     * Events are also tracked on interaction with the alert.
-     *
-     * @param context Fragment context for resolving message strings and displaying the dialog
-     * @param errorResId Reference to the localized string resource for message
-     * @param errorCode Http Status Code for feedback message
-     * @param errorMessage API error response for feedback message
-     * @param errorType IAP [ErrorMessage] type/code for feedback message
-     * @param retryListener Retry listener to fetch the upgraded course again or to verify the
-     * purchase
-     * @param cancelListener Cancel listener to reset the purchase flow
-     */
-    fun showPostUpgradeErrorDialog(
-        context: Fragment,
-        @StringRes errorResId: Int = R.string.error_course_not_fullfilled,
-        errorCode: Int? = null,
-        errorMessage: String? = null,
-        errorType: Int? = null,
-        retryListener: DialogInterface.OnClickListener? = null,
-        cancelListener: DialogInterface.OnClickListener? = null
-    ) {
-
-        val feedbackErrorMessage: String = TextUtils.getFormattedErrorMessage(
-            errorCode,
-            errorType,
-            errorMessage
-        ).toString()
-
-        iapAnalytics.trackIAPEvent(
-            eventName = Events.IAP_COURSE_UPGRADE_ERROR,
-            errorMsg = feedbackErrorMessage
-        )
-        AlertDialogFragment.newInstance(
-            context.getString(R.string.title_upgrade_error),
-            context.getString(errorResId),
-            context.getString(
-                if (errorCode == HttpStatus.NOT_ACCEPTABLE) R.string.label_refresh_now
-                else R.string.label_refresh_to_retry
-            ),
-            { dialog, which ->
-                retryListener?.onClick(dialog, which).also {
-                    if (errorCode == HttpStatus.NOT_ACCEPTABLE) {
-                        // Add Analytics for refresh course on unfulfilled payments
-                    } else {
-                        iapAnalytics.initRefreshContentTime()
-                        iapAnalytics.trackIAPEvent(
-                            eventName = Events.IAP_ERROR_ALERT_ACTION,
-                            errorMsg = feedbackErrorMessage,
-                            actionTaken = Values.ACTION_REFRESH
-                        )
-                    }
-                }
-            },
-            context.getString(R.string.label_get_help),
-            { dialog, which ->
-                cancelListener?.onClick(dialog, which).also {
-                    showFeedbackScreen(context, feedbackErrorMessage)
-                }
-            },
-            context.getString(R.string.label_cancel),
-            { dialog, which ->
-                cancelListener?.onClick(dialog, which).also {
-                    trackAlertCloseEvent(feedbackErrorMessage)
-                }
-            }, false
-        ).show(context.childFragmentManager, null)
-    }
-
-    private fun trackAlertCloseEvent(feedbackErrorMessage: String) {
-        iapAnalytics.trackIAPEvent(
-            eventName = Events.IAP_ERROR_ALERT_ACTION,
-            errorMsg = feedbackErrorMessage,
-            actionTaken = Values.ACTION_CLOSE
-        )
-    }
-
-    private fun showFeedbackScreen(context: Fragment, feedbackErrorMessage: String) {
-        environment.router?.showFeedbackScreen(
-            context.requireActivity(),
-            context.getString(R.string.email_subject_upgrade_error),
-            feedbackErrorMessage
-        )
-        iapAnalytics.trackIAPEvent(
-            eventName = Events.IAP_ERROR_ALERT_ACTION,
-            errorMsg = feedbackErrorMessage,
-            actionTaken = Values.ACTION_GET_HELP
-        )
-    }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/TextUtils.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/TextUtils.java
@@ -192,20 +192,18 @@ public class TextUtils {
      * Returns a StringBuilder containing the formatted error message.
      * i.e Error: error_endpoint-error_code-error_message
      *
-     * @param errorCode     HTTP or SDK response code
-     * @param errorEndpoint Call endpoint
-     * @param errorMessage  Error message from HTTP call or SDK
+     * @param requestType  Call endpoint
+     * @param errorCode    HTTP or SDK response code
+     * @param errorMessage Error message from HTTP call or SDK
      * @return Formatted error message.
      */
-    public static StringBuilder getFormattedErrorMessage(
-            Integer errorCode,
-            Integer errorEndpoint,
-            String errorMessage) {
+    public static StringBuilder getFormattedErrorMessage(int requestType, int errorCode, String errorMessage) {
         StringBuilder body = new StringBuilder();
-        if (errorEndpoint == null) return body;
-
+        if (requestType == 0) {
+            return body;
+        }
         String endpoint;
-        switch (errorEndpoint) {
+        switch (requestType) {
             case ErrorMessage.ADD_TO_BASKET_CODE:
                 endpoint = "basket";
                 break;
@@ -224,12 +222,13 @@ public class TextUtils {
             default:
                 endpoint = "unhandledError";
         }
-
         body.append(String.format("%s", endpoint));
-        if (errorCode == null) return body;
+        // change the default value to -1 cuz in case of BillingClient return errorCode 0 for price load.
+        if (errorCode == -1) {
+            return body;
+        }
         body.append(String.format(Locale.ENGLISH, "-%d", errorCode));
-
-        if (errorMessage != null && !errorMessage.isEmpty())
+        if (!android.text.TextUtils.isEmpty(errorMessage))
             body.append(String.format("-%s", errorMessage));
         return body;
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/AccountFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/AccountFragment.kt
@@ -28,7 +28,12 @@ import org.edx.mobile.module.prefs.LoginPrefs
 import org.edx.mobile.module.prefs.PrefManager
 import org.edx.mobile.user.UserAPI.AccountDataUpdatedCallback
 import org.edx.mobile.user.UserService
-import org.edx.mobile.util.*
+import org.edx.mobile.util.AppConstants
+import org.edx.mobile.util.BrowserUtil
+import org.edx.mobile.util.Config
+import org.edx.mobile.util.FileUtil
+import org.edx.mobile.util.ResourceUtil
+import org.edx.mobile.util.UserProfileUtils
 import org.edx.mobile.view.dialog.IDialogCallback
 import org.edx.mobile.view.dialog.NetworkCheckDialogFragment
 import org.edx.mobile.view.dialog.VideoDownloadQualityDialogFragment

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDatesPageFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDatesPageFragment.kt
@@ -231,7 +231,7 @@ class CourseDatesPageFragment : OfflineSupportBaseFragment(), BaseFragment.Permi
                             )
                     }
                 } else {
-                    when (errorMsg.errorCode) {
+                    when (errorMsg.requestType) {
                         ErrorMessage.COURSE_DATES_CODE ->
                             errorNotification.showError(
                                 contextOrThrow,

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -285,7 +285,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
                             environment.getAnalyticsRegistry(),
                             environment.getNotificationDelegate());
                 } else {
-                    switch (errorMessage.getErrorCode()) {
+                    switch (errorMessage.getRequestType()) {
                         case ErrorMessage.BANNER_INFO_CODE:
                             initDatesBanner(null);
                             break;
@@ -492,7 +492,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
                     errorNotification.showError(getContext(), error);
                     logger.error(error, true);
                 } else if (fullscreenLoader != null && fullscreenLoader.isAdded()) {
-                    iapViewModel.setError(ErrorMessage.COURSE_REFRESH_CODE, error);
+                    iapViewModel.dispatchError(ErrorMessage.COURSE_REFRESH_CODE, null, error);
                 }
                 swipeContainer.setRefreshing(false);
                 // Remove bulk video download if the course has NO downloadable videos

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -625,7 +625,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
             if (listView.getHeaderViewsCount() == 0 && bannerViewBinding.getRoot().getVisibility() == View.VISIBLE) {
                 listView.addHeaderView(bannerViewBinding.getRoot());
                 isBannerVisible = true;
-            } else {
+            } else if (EnrollmentMode.VERIFIED.toString().equalsIgnoreCase(courseData.getMode())) {
                 listView.removeHeaderView(bannerViewBinding.getRoot());
                 isBannerVisible = false;
             }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
@@ -277,7 +277,7 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
     @Override
     protected void onCourseRefreshError(Throwable error) {
         if (fullScreenLoader != null && fullScreenLoader.isAdded()) {
-            iapViewModel.setError(ErrorMessage.COURSE_REFRESH_CODE, error);
+            iapViewModel.dispatchError(ErrorMessage.COURSE_REFRESH_CODE, null, error);
         }
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitWebViewFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitWebViewFragment.java
@@ -306,7 +306,7 @@ public class CourseUnitWebViewFragment extends CourseUnitFragment {
                             environment.getAnalyticsRegistry(),
                             environment.getNotificationDelegate());
                 } else {
-                    switch (errorMessage.getErrorCode()) {
+                    switch (errorMessage.getRequestType()) {
                         case ErrorMessage.BANNER_INFO_CODE:
                             initInfoBanner(null);
                             break;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
@@ -1,5 +1,6 @@
 package org.edx.mobile.view.dialog
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -7,8 +8,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
-import com.android.billingclient.api.BillingResult
-import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.SkuDetails
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import org.edx.mobile.R
@@ -17,29 +17,21 @@ import org.edx.mobile.databinding.DialogUpgradeFeaturesBinding
 import org.edx.mobile.exception.ErrorMessage
 import org.edx.mobile.extenstion.setVisibility
 import org.edx.mobile.http.HttpStatus
-import org.edx.mobile.inapppurchases.BillingProcessor
 import org.edx.mobile.module.analytics.Analytics
 import org.edx.mobile.module.analytics.Analytics.Events
 import org.edx.mobile.module.analytics.InAppPurchasesAnalytics
 import org.edx.mobile.util.AppConstants
 import org.edx.mobile.util.InAppPurchasesException
-import org.edx.mobile.util.InAppPurchasesUtils
 import org.edx.mobile.util.NonNullObserver
 import org.edx.mobile.util.ResourceUtil
 import org.edx.mobile.viewModel.InAppPurchasesViewModel
+import org.edx.mobile.wrapper.InAppPurchasesDialog
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class CourseModalDialogFragment : DialogFragment() {
 
     private lateinit var binding: DialogUpgradeFeaturesBinding
-    private var screenName: String = ""
-    private var courseId: String = ""
-    private var courseSku: String? = null
-    private var isSelfPaced: Boolean = false
-    private var isPurchaseEnabled: Boolean = false
-
-    private var billingProcessor: BillingProcessor? = null
 
     private val iapViewModel: InAppPurchasesViewModel
             by viewModels(ownerProducer = { requireActivity() })
@@ -51,7 +43,12 @@ class CourseModalDialogFragment : DialogFragment() {
     lateinit var iapAnalytics: InAppPurchasesAnalytics
 
     @Inject
-    lateinit var iapUtils: InAppPurchasesUtils
+    lateinit var iapDialog: InAppPurchasesDialog
+
+    private var screenName: String = ""
+    private var courseId: String = ""
+    private var courseSku: String? = null
+    private var isSelfPaced: Boolean = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -76,12 +73,7 @@ class CourseModalDialogFragment : DialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        isPurchaseEnabled =
-            environment.appFeaturesPrefs.isIAPEnabled(environment.loginPrefs.isOddUserId)
         initViews()
-        if (isPurchaseEnabled) {
-            initBillingProcessor()
-        }
     }
 
     private fun initViews() {
@@ -99,9 +91,21 @@ class CourseModalDialogFragment : DialogFragment() {
             KEY_COURSE_NAME,
             arguments?.getString(KEY_COURSE_NAME)
         )
+        val isPurchaseEnabled =
+            environment.appFeaturesPrefs.isIAPEnabled(environment.loginPrefs.isOddUserId)
         binding.layoutUpgradeBtn.root.setVisibility(isPurchaseEnabled)
         binding.dialogDismiss.setOnClickListener {
             dialog?.dismiss()
+        }
+        if (isPurchaseEnabled) {
+            initIAPObservers()
+            // Shimmer container taking sometime to get ready and perform the animation, so
+            // by adding the some delay fixed that issue for lower-end devices, and for the
+            // proper animation.
+            binding.layoutUpgradeBtn.shimmerViewContainer.postDelayed({
+                iapViewModel.initializeProductPrice(courseSku)
+            }, 1500)
+            binding.layoutUpgradeBtn.btnUpgrade.isEnabled = false
         }
     }
 
@@ -132,171 +136,85 @@ class CourseModalDialogFragment : DialogFragment() {
         )
     }
 
-    private fun initBillingProcessor() {
-        initObserver()
+    private fun initIAPObservers() {
+        iapViewModel.productPrice.observe(viewLifecycleOwner, NonNullObserver { skuDetails ->
+            setUpUpgradeButton(skuDetails)
+        })
 
-        binding.layoutUpgradeBtn.btnUpgrade.setOnClickListener {
-            iapAnalytics.trackIAPEvent(eventName = Events.IAP_UPGRADE_NOW_CLICKED)
-            courseSku?.let {
-                iapViewModel.addProductToBasket(it)
-            } ?: iapUtils.showUpgradeErrorDialog(this)
-        }
-        billingProcessor =
-            BillingProcessor(requireContext(), object : BillingProcessor.BillingFlowListeners {
-                override fun onBillingSetupFinished(billingResult: BillingResult) {
-                    super.onBillingSetupFinished(billingResult)
-                    // Shimmer container taking sometime to get ready and perform the animation, so
-                    // by adding the some delay fixed that issue for lower-end devices, and for the
-                    // proper animation.
-                    binding.layoutUpgradeBtn.shimmerViewContainer.postDelayed({
-                        initializeProductPrice()
-                    }, 1500)
-                    binding.layoutUpgradeBtn.btnUpgrade.isEnabled = false
-                }
-
-                override fun onPurchaseCancel(responseCode: Int, message: String) {
-                    iapViewModel.endLoading()
-                    iapUtils.showUpgradeErrorDialog(
-                        context = this@CourseModalDialogFragment,
-                        errorResId = R.string.error_payment_not_processed,
-                        errorCode = responseCode,
-                        errorMessage = message,
-                        errorType = ErrorMessage.PAYMENT_SDK_CODE
-                    )
-                }
-
-                override fun onPurchaseComplete(purchase: Purchase) {
-                    onProductPurchased(purchase.purchaseToken)
-                }
-            })
-    }
-
-    private fun initializeProductPrice() {
-        iapAnalytics.initPriceTime()
-        courseSku?.let {
-            billingProcessor?.querySyncDetails(
-                productId = it
-            ) { _, skuDetails ->
-                val skuDetail = skuDetails?.get(0)
-                if (skuDetail?.sku == it) {
-                    binding.layoutUpgradeBtn.btnUpgrade.text =
-                        ResourceUtil.getFormattedString(
-                            resources,
-                            R.string.label_upgrade_course_button,
-                            AppConstants.PRICE,
-                            skuDetail.price
-                        ).toString()
-                    // The app get the sku details instantly, so add some wait to perform
-                    // animation at least one cycle.
-                    binding.layoutUpgradeBtn.shimmerViewContainer.postDelayed({
-                        binding.layoutUpgradeBtn.shimmerViewContainer.hideShimmer()
-                        binding.layoutUpgradeBtn.btnUpgrade.isEnabled = true
-                    }, 500)
-                    iapAnalytics.setPrice(skuDetail.price)
-                    iapAnalytics.trackIAPEvent(Events.IAP_LOAD_PRICE_TIME)
-                } else {
-                    iapUtils.showUpgradeErrorDialog(
-                        context = this@CourseModalDialogFragment,
-                        errorResId = R.string.error_price_not_fetched,
-                        errorType = ErrorMessage.PRICE_CODE,
-                        listener = { _, _ ->
-                            initializeProductPrice()
-                        })
-                }
-            }
-        } ?: iapUtils.showUpgradeErrorDialog(
-            context = this@CourseModalDialogFragment,
-            errorResId = R.string.error_price_not_fetched,
-            errorType = ErrorMessage.PRICE_CODE,
-            listener = { _, _ ->
-                initializeProductPrice()
-            })
-    }
-
-    private fun initObserver() {
         iapViewModel.showLoader.observe(viewLifecycleOwner, NonNullObserver {
             enableUpgradeButton(!it)
         })
 
-        iapViewModel.checkoutResponse.observe(viewLifecycleOwner, NonNullObserver {
-            if (it.paymentPageUrl.isNotEmpty()) {
-                iapAnalytics.initPaymentTime()
-                purchaseProduct(iapViewModel.productId)
-            }
-        })
-
-        iapViewModel.errorMessage.observe(viewLifecycleOwner, NonNullObserver { errorMsg ->
-            if (errorMsg.throwable is InAppPurchasesException) {
-                when (errorMsg.throwable.httpErrorCode) {
-                    HttpStatus.UNAUTHORIZED -> {
-                        environment.router?.forceLogout(
-                            requireContext(),
-                            environment.analyticsRegistry,
-                            environment.notificationDelegate
-                        )
-                        return@NonNullObserver
-                    }
-                    HttpStatus.NOT_ACCEPTABLE -> {
-                        iapUtils.showPostUpgradeErrorDialog(
-                            context = this@CourseModalDialogFragment,
-                            errorResId = errorMsg.errorResId,
-                            errorCode = errorMsg.throwable.httpErrorCode,
-                            errorMessage = errorMsg.throwable.errorMessage,
-                            errorType = errorMsg.errorCode,
-                            retryListener = { _, _ ->
-                                iapViewModel.upgradeMode =
-                                    InAppPurchasesViewModel.UpgradeMode.SILENT
-                                iapViewModel.showFullScreenLoader(true)
-                                dismiss()
-                            },
-                            cancelListener = null
-                        )
-                    }
-                    else -> iapUtils.showUpgradeErrorDialog(
-                        context = this@CourseModalDialogFragment,
-                        errorResId = errorMsg.errorResId,
-                        errorCode = errorMsg.throwable.httpErrorCode,
-                        errorMessage = errorMsg.throwable.errorMessage,
-                        errorType = errorMsg.errorCode
-                    )
-                }
-            } else {
-                iapUtils.showUpgradeErrorDialog(
-                    context = this@CourseModalDialogFragment,
-                    errorResId = errorMsg.errorResId,
-                    errorType = errorMsg.errorCode
-                )
-            }
+        iapViewModel.errorMessage.observe(viewLifecycleOwner, NonNullObserver { errorMessage ->
+            handleIAPException(errorMessage)
             iapViewModel.errorMessageShown()
         })
+
+        iapViewModel.productPurchased.observe(viewLifecycleOwner, NonNullObserver {
+            lifecycleScope.launch {
+                iapViewModel.showFullScreenLoader(true)
+                dismiss()
+            }
+        })
+    }
+
+    private fun setUpUpgradeButton(skuDetails: SkuDetails) {
+        binding.layoutUpgradeBtn.btnUpgrade.text =
+            ResourceUtil.getFormattedString(
+                resources,
+                R.string.label_upgrade_course_button,
+                AppConstants.PRICE,
+                skuDetails.price
+            ).toString()
+        // The app get the sku details instantly, so add some wait to perform
+        // animation at least one cycle.
+        binding.layoutUpgradeBtn.shimmerViewContainer.postDelayed({
+            binding.layoutUpgradeBtn.shimmerViewContainer.hideShimmer()
+            binding.layoutUpgradeBtn.btnUpgrade.isEnabled = true
+        }, 500)
+
+        binding.layoutUpgradeBtn.btnUpgrade.setOnClickListener {
+            iapAnalytics.trackIAPEvent(eventName = Events.IAP_UPGRADE_NOW_CLICKED)
+            environment.loginPrefs.userId?.let { userId ->
+                courseSku?.let {
+                    iapViewModel.addProductToBasket(
+                        activity = requireActivity(),
+                        userId = userId,
+                        productId = it
+                    )
+                } ?: iapDialog.showUpgradeErrorDialog(this)
+            }
+        }
+    }
+
+    private fun handleIAPException(errorMessage: ErrorMessage) {
+        var retryListener: DialogInterface.OnClickListener? = null
+        if (HttpStatus.NOT_ACCEPTABLE == (errorMessage.throwable as InAppPurchasesException).httpErrorCode) {
+            retryListener = DialogInterface.OnClickListener { _, _ ->
+                iapViewModel.upgradeMode = InAppPurchasesViewModel.UpgradeMode.SILENT
+                iapViewModel.showFullScreenLoader(true)
+                dismiss()
+            }
+        } else if (errorMessage.canRetry()) {
+            retryListener = DialogInterface.OnClickListener { _, _ ->
+                when (errorMessage.requestType) {
+                    ErrorMessage.PRICE_CODE -> {
+                        iapViewModel.initializeProductPrice(courseSku)
+                    }
+                }
+            }
+        }
+        iapDialog.handleIAPException(
+            fragment =
+            this@CourseModalDialogFragment,
+            errorMessage = errorMessage,
+            retryListener = retryListener
+        )
     }
 
     private fun enableUpgradeButton(enable: Boolean) {
         binding.layoutUpgradeBtn.btnUpgrade.setVisibility(enable)
         binding.layoutUpgradeBtn.loadingIndicator.setVisibility(!enable)
-    }
-
-    private fun purchaseProduct(productId: String) {
-        activity?.let { context ->
-            environment.loginPrefs.userId?.let { userId ->
-                billingProcessor?.purchaseItem(context, productId, userId)
-            }
-        }
-    }
-
-    private fun onProductPurchased(purchaseToken: String) {
-        lifecycleScope.launch {
-            iapAnalytics.trackIAPEvent(eventName = Events.IAP_PAYMENT_TIME)
-            iapAnalytics.initUnlockContentTime()
-            iapViewModel.setPurchaseToken(purchaseToken)
-            iapViewModel.showFullScreenLoader(true)
-            dismiss()
-        }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        billingProcessor?.disconnect()
     }
 
     companion object {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/InAppPurchasesViewModel.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/InAppPurchasesViewModel.kt
@@ -1,33 +1,43 @@
 package org.edx.mobile.viewModel
 
+import android.app.Activity
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.SkuDetails
 import dagger.hilt.android.lifecycle.HiltViewModel
-import org.edx.mobile.R
+import kotlinx.coroutines.launch
 import org.edx.mobile.exception.ErrorMessage
+import org.edx.mobile.extenstion.decodeToLong
 import org.edx.mobile.http.model.NetworkResponseCallback
 import org.edx.mobile.http.model.Result
+import org.edx.mobile.inapppurchases.BillingProcessor
+import org.edx.mobile.model.api.EnrolledCoursesResponse
+import org.edx.mobile.model.api.getAuditCoursesSku
 import org.edx.mobile.model.iap.AddToBasketResponse
 import org.edx.mobile.model.iap.CheckoutResponse
 import org.edx.mobile.model.iap.ExecuteOrderResponse
+import org.edx.mobile.module.analytics.Analytics
+import org.edx.mobile.module.analytics.InAppPurchasesAnalytics
 import org.edx.mobile.repository.InAppPurchasesRepository
 import org.edx.mobile.util.InAppPurchasesException
+import org.edx.mobile.util.InAppPurchasesUtils
 import javax.inject.Inject
 
 @HiltViewModel
 class InAppPurchasesViewModel @Inject constructor(
-    private val repository: InAppPurchasesRepository
+    private val billingProcessor: BillingProcessor,
+    private val repository: InAppPurchasesRepository,
+    private val iapAnalytics: InAppPurchasesAnalytics
 ) : ViewModel() {
 
-    private val _showLoader = MutableLiveData(false)
-    val showLoader: LiveData<Boolean> = _showLoader
+    private val _productPrice = MutableLiveData<SkuDetails>()
+    val productPrice: LiveData<SkuDetails> = _productPrice
 
-    private val _errorMessage = MutableLiveData<ErrorMessage?>()
-    val errorMessage: LiveData<ErrorMessage?> = _errorMessage
-
-    private val _checkoutResponse = MutableLiveData<CheckoutResponse>()
-    val checkoutResponse: LiveData<CheckoutResponse> = _checkoutResponse
+    private val _productPurchased = MutableLiveData<Purchase>()
+    val productPurchased: LiveData<Purchase> = _productPurchased
 
     private val _executeResponse = MutableLiveData<ExecuteOrderResponse>()
     val executeResponse: LiveData<ExecuteOrderResponse> = _executeResponse
@@ -35,11 +45,20 @@ class InAppPurchasesViewModel @Inject constructor(
     private val _showFullscreenLoaderDialog = MutableLiveData(false)
     val showFullscreenLoaderDialog: LiveData<Boolean> = _showFullscreenLoaderDialog
 
+    private val _purchaseFlowComplete = MutableLiveData(false)
+    val purchaseFlowComplete: LiveData<Boolean> = _purchaseFlowComplete
+
     private val _refreshCourseData = MutableLiveData(false)
     val refreshCourseData: LiveData<Boolean> = _refreshCourseData
 
-    private val _purchaseFlowComplete = MutableLiveData(false)
-    val purchaseFlowComplete: LiveData<Boolean> = _purchaseFlowComplete
+    private val _completedUnfulfilledPurchase = MutableLiveData<Boolean>()
+    val completedUnfulfilledPurchase: LiveData<Boolean> = _completedUnfulfilledPurchase
+
+    private val _showLoader = MutableLiveData(false)
+    val showLoader: LiveData<Boolean> = _showLoader
+
+    private val _errorMessage = MutableLiveData<ErrorMessage?>()
+    val errorMessage: LiveData<ErrorMessage?> = _errorMessage
 
     var upgradeMode = UpgradeMode.NORMAL
 
@@ -53,46 +72,107 @@ class InAppPurchasesViewModel @Inject constructor(
 
     private var basketId: Long = 0
     private var purchaseToken: String = ""
+    private var incompletePurchases: MutableList<Pair<String, String>> = arrayListOf()
+    private var userId: Long = 0
 
-    fun addProductToBasket(productId: String) {
+    private val listener = object : BillingProcessor.BillingFlowListeners {
+        override fun onPurchaseCancel(responseCode: Int, message: String) {
+            super.onPurchaseCancel(responseCode, message)
+            dispatchError(
+                requestType = ErrorMessage.PAYMENT_SDK_CODE,
+                throwable = InAppPurchasesException(responseCode, message)
+            )
+            endLoading()
+        }
+
+        override fun onPurchaseComplete(purchase: Purchase) {
+            super.onPurchaseComplete(purchase)
+            purchaseToken = purchase.purchaseToken
+            _productPurchased.postValue(purchase)
+            iapAnalytics.trackIAPEvent(eventName = Analytics.Events.IAP_PAYMENT_TIME)
+            iapAnalytics.initUnlockContentTime()
+        }
+    }
+
+    init {
+        billingProcessor.setUpBillingFlowListeners(listener)
+        billingProcessor.startConnection()
+    }
+
+    fun initializeProductPrice(courseSku: String?) {
+        iapAnalytics.initPriceTime()
+        courseSku?.let {
+            billingProcessor.querySyncDetails(
+                productId = courseSku
+            ) { billingResult, skuDetails ->
+                val skuDetail = skuDetails?.get(0)
+                skuDetail?.let {
+                    if (it.sku == courseSku) {
+                        _productPrice.postValue(it)
+                        iapAnalytics.setPrice(skuDetail.price)
+                        iapAnalytics.trackIAPEvent(Analytics.Events.IAP_LOAD_PRICE_TIME)
+                    }
+                } ?: dispatchError(
+                    requestType = ErrorMessage.PRICE_CODE,
+                    throwable = InAppPurchasesException(
+                        httpErrorCode = billingResult.responseCode,
+                        errorMessage = billingResult.debugMessage,
+                    )
+                )
+            }
+        } ?: dispatchError(requestType = ErrorMessage.PRICE_CODE)
+    }
+
+    fun addProductToBasket(activity: Activity, userId: Long, productId: String) {
         this._productId = productId
+        this.userId = userId
         startLoading()
         repository.addToBasket(
             productId = productId,
             callback = object : NetworkResponseCallback<AddToBasketResponse> {
                 override fun onSuccess(result: Result.Success<AddToBasketResponse>) {
                     result.data?.let {
-                        proceedCheckout(it.basketId)
+                        proceedCheckout(activity, it.basketId)
                     } ?: endLoading()
                 }
 
                 override fun onError(error: Result.Error) {
+                    dispatchError(
+                        requestType = ErrorMessage.ADD_TO_BASKET_CODE,
+                        throwable = error.throwable
+                    )
                     endLoading()
-                    setError(ErrorMessage.ADD_TO_BASKET_CODE, error.throwable)
                 }
             })
     }
 
-    fun proceedCheckout(basketId: Long) {
+    fun proceedCheckout(activity: Activity, basketId: Long) {
         this.basketId = basketId
         repository.proceedCheckout(
             basketId = basketId,
             callback = object : NetworkResponseCallback<CheckoutResponse> {
                 override fun onSuccess(result: Result.Success<CheckoutResponse>) {
                     result.data?.let {
-                        if (upgradeMode.isSilentMode()) executeOrder()
-                        else _checkoutResponse.value = it
+                        if (upgradeMode.isSilentMode()) {
+                            executeOrder(activity)
+                        } else {
+                            iapAnalytics.initPaymentTime()
+                            billingProcessor.purchaseItem(activity, productId, userId)
+                        }
                     } ?: endLoading()
                 }
 
                 override fun onError(error: Result.Error) {
+                    dispatchError(
+                        requestType = ErrorMessage.CHECKOUT_CODE,
+                        throwable = error.throwable
+                    )
                     endLoading()
-                    setError(ErrorMessage.CHECKOUT_CODE, error.throwable)
                 }
             })
     }
 
-    fun executeOrder() {
+    fun executeOrder(activity: Activity) {
         _isVerificationPending = false
         repository.executeOrder(
             basketId = basketId,
@@ -102,49 +182,111 @@ class InAppPurchasesViewModel @Inject constructor(
                 override fun onSuccess(result: Result.Success<ExecuteOrderResponse>) {
                     result.data?.let {
                         orderExecuted()
-                        if (upgradeMode.isSilentMode()) _executeResponse.postValue(it)
-                        else refreshCourseData(true)
+                        if (upgradeMode.isSilentMode()) {
+                            markPurchaseComplete(activity)
+                            _executeResponse.postValue(it)
+                        } else {
+                            refreshCourseData(true)
+                        }
                     }
                     endLoading()
                 }
 
                 override fun onError(error: Result.Error) {
+                    dispatchError(
+                        requestType = ErrorMessage.EXECUTE_ORDER_CODE,
+                        throwable = error.throwable
+                    )
                     endLoading()
-                    setError(ErrorMessage.EXECUTE_ORDER_CODE, error.throwable)
                 }
             })
+    }
+
+    fun detectUnfulfilledPurchase(
+        activity: Activity,
+        userId: Long,
+        enrolledCourses: List<EnrolledCoursesResponse>
+    ) {
+        val auditCoursesSku = enrolledCourses.getAuditCoursesSku()
+        if (auditCoursesSku.isEmpty()) {
+            _completedUnfulfilledPurchase.postValue(true)
+            return
+        }
+        this.userId = userId
+        billingProcessor.queryPurchase { _, purchases ->
+            if (purchases.isEmpty()) {
+                return@queryPurchase
+            }
+            val purchasesList =
+                purchases.filter { it.accountIdentifiers?.obfuscatedAccountId?.decodeToLong() == userId }
+                    .associate { it.skus[0] to it.purchaseToken }
+                    .toList()
+            if (purchasesList.isNotEmpty()) {
+                incompletePurchases = InAppPurchasesUtils.getInCompletePurchases(
+                    auditCoursesSku,
+                    purchasesList
+                )
+                completePurchasesFlow(activity)
+            } else {
+                _completedUnfulfilledPurchase.postValue(true)
+            }
+        }
+    }
+
+    /**
+     * To detect and handle courses which are purchased but still not Verified
+     *
+     * @param activity: context of the activity trigger to handle the incomplete purchases flow.
+     * @return incompletePurchases after dropout the verified one.
+     */
+    private fun completePurchasesFlow(activity: Activity) {
+        if (incompletePurchases.isNotEmpty()) {
+            viewModelScope.launch {
+                upgradeMode = UpgradeMode.SILENT
+                purchaseToken = incompletePurchases[0].second
+                addProductToBasket(activity, userId, incompletePurchases[0].first)
+            }
+        } else {
+            _completedUnfulfilledPurchase.postValue(true)
+        }
+    }
+
+    private fun markPurchaseComplete(activity: Activity) {
+        incompletePurchases = incompletePurchases.drop(1).toMutableList()
+        completePurchasesFlow(activity)
+    }
+
+    fun dispatchError(
+        requestType: Int = 0,
+        errorMessage: String? = null,
+        throwable: Throwable? = null
+    ) {
+        var actualErrorMessage = errorMessage
+        throwable?.let {
+            if (errorMessage.isNullOrBlank()) {
+                actualErrorMessage = it.message
+            }
+        }
+        if (throwable != null && throwable is InAppPurchasesException) {
+            _errorMessage.postValue(ErrorMessage(requestType = requestType, throwable = throwable))
+        } else {
+            _errorMessage.postValue(
+                ErrorMessage(
+                    requestType = requestType,
+                    throwable = InAppPurchasesException(errorMessage = actualErrorMessage)
+                )
+            )
+        }
     }
 
     private fun orderExecuted() {
         _productId = ""
         basketId = 0
-    }
-
-    fun setError(errorCode: Int, throwable: Throwable) {
-        _errorMessage.value = ErrorMessage(errorCode, throwable, getErrorMessage(throwable))
+        userId = 0
     }
 
     fun errorMessageShown() {
         _errorMessage.value = null
-    }
-
-    private fun getErrorMessage(throwable: Throwable) = if (throwable is InAppPurchasesException) {
-        when (throwable.httpErrorCode) {
-            400 -> when (throwable.errorCode) {
-                ErrorMessage.ADD_TO_BASKET_CODE -> R.string.error_course_not_found
-                ErrorMessage.CHECKOUT_CODE -> R.string.error_payment_not_processed
-                ErrorMessage.EXECUTE_ORDER_CODE -> R.string.error_course_not_fullfilled
-                else -> R.string.general_error_message
-            }
-            403 -> when (throwable.errorCode) {
-                ErrorMessage.EXECUTE_ORDER_CODE -> R.string.error_course_not_fullfilled
-                else -> R.string.error_user_not_authenticated
-            }
-            406 -> R.string.error_course_already_paid
-            else -> R.string.general_error_message
-        }
-    } else {
-        R.string.general_error_message
     }
 
     private fun startLoading() {
@@ -153,10 +295,6 @@ class InAppPurchasesViewModel @Inject constructor(
 
     fun endLoading() {
         _showLoader.postValue(false)
-    }
-
-    fun setPurchaseToken(purchaseToken: String) {
-        this.purchaseToken = purchaseToken
     }
 
     fun showFullScreenLoader(show: Boolean) {
@@ -172,6 +310,11 @@ class InAppPurchasesViewModel @Inject constructor(
         upgradeMode = UpgradeMode.NORMAL
         _isVerificationPending = true
         _purchaseFlowComplete.postValue(complete)
+    }
+
+    override fun onCleared() {
+        billingProcessor.disconnect()
+        super.onCleared()
     }
 
     enum class UpgradeMode {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/wrapper/InAppPurchasesDialog.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/wrapper/InAppPurchasesDialog.kt
@@ -1,0 +1,276 @@
+package org.edx.mobile.wrapper
+
+import android.content.DialogInterface
+import androidx.annotation.StringRes
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.Fragment
+import org.edx.mobile.R
+import org.edx.mobile.core.IEdxEnvironment
+import org.edx.mobile.exception.ErrorMessage
+import org.edx.mobile.http.HttpStatus
+import org.edx.mobile.module.analytics.Analytics
+import org.edx.mobile.module.analytics.InAppPurchasesAnalytics
+import org.edx.mobile.util.InAppPurchasesException
+import org.edx.mobile.util.InAppPurchasesUtils
+import org.edx.mobile.util.TextUtils
+import org.edx.mobile.view.dialog.AlertDialogFragment
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class InAppPurchasesDialog @Inject constructor(
+    var environment: IEdxEnvironment,
+    var iapAnalytics: InAppPurchasesAnalytics
+) {
+
+    fun handleIAPException(
+        fragment: Fragment,
+        errorMessage: ErrorMessage,
+        retryListener: DialogInterface.OnClickListener?,
+        cancelListener: DialogInterface.OnClickListener? = null
+    ) {
+        errorMessage.throwable as InAppPurchasesException
+        when (errorMessage.throwable.httpErrorCode) {
+            HttpStatus.UNAUTHORIZED -> {
+                environment.router?.forceLogout(
+                    fragment.requireContext(),
+                    environment.analyticsRegistry,
+                    environment.notificationDelegate
+                )
+                return
+            }
+            else -> {
+                cancelListener?.let {
+                    showPostUpgradeErrorDialog(
+                        context = fragment,
+                        errorMessage = errorMessage,
+                        retryListener = retryListener,
+                        cancelListener = cancelListener
+                    )
+                } ?: showUpgradeErrorDialog(
+                    context = fragment,
+                    errorMessage = errorMessage,
+                    retryListener = retryListener
+                )
+            }
+        }
+    }
+
+    /**
+     * Shows Alert Dialog for all error cases that can occur before a successful course purchase i.e
+     * SKU/Product ID not available (Enrollment-API), while fetching the price from Play Console
+     * (Payment SDK), Adding course in purchase basket/cart (Basket-API), during basket checkout
+     * (Checkout-API) or while purchasing a course (Payment SDK).
+     *
+     * All Alerts (except Price Fetching): Two buttons; Cancel and Get help, without any listener
+     * Fetching Price Alert: Two buttons; Try again & Cancel, with a listener for Try again
+     *
+     * Events are also tracked on interaction with the alert.
+     *
+     * @param context Fragment context for resolving message strings and displaying the dialog
+     * @param errorMessage API error response for feedback message
+     * @param retryListener Retry listener to fetch the course price again
+     */
+    fun showUpgradeErrorDialog(
+        context: Fragment,
+        errorMessage: ErrorMessage = ErrorMessage(0, InAppPurchasesException()),
+        retryListener: DialogInterface.OnClickListener? = null,
+    ) {
+        // To restrict showing error dialog on an unattached fragment
+        if (!context.isAdded) return
+        errorMessage.throwable as InAppPurchasesException
+
+        val feedbackErrorMessage: String = TextUtils.getFormattedErrorMessage(
+            errorMessage.requestType,
+            errorMessage.getHttpErrorCode(),
+            errorMessage.getErrorMessage()
+        ).toString()
+
+        when (errorMessage.requestType) {
+            ErrorMessage.PAYMENT_SDK_CODE -> iapAnalytics.trackIAPEvent(
+                eventName = Analytics.Events.IAP_PAYMENT_ERROR,
+                errorMsg = feedbackErrorMessage
+            )
+            ErrorMessage.PRICE_CODE -> iapAnalytics.trackIAPEvent(
+                eventName = Analytics.Events.IAP_PRICE_LOAD_ERROR,
+                errorMsg = feedbackErrorMessage
+            )
+            else -> iapAnalytics.trackIAPEvent(
+                eventName = Analytics.Events.IAP_COURSE_UPGRADE_ERROR,
+                errorMsg = feedbackErrorMessage
+            )
+        }
+        @StringRes val errorResId =
+            InAppPurchasesUtils.getErrorMessage(
+                errorMessage.requestType,
+                errorMessage.getHttpErrorCode()
+            )
+
+        var actionTaken: String = Analytics.Values.ACTION_CLOSE
+        @StringRes var positiveBtnResId = R.string.label_close
+        if (retryListener != null) {
+            when (errorMessage.getHttpErrorCode()) {
+                HttpStatus.NOT_ACCEPTABLE -> {
+                    positiveBtnResId = R.string.label_refresh_now
+                    actionTaken = Analytics.Values.ACTION_REFRESH
+                }
+                else -> {
+                    positiveBtnResId = R.string.try_again
+                    actionTaken = Analytics.Values.ACTION_RELOAD_PRICE
+                }
+            }
+        }
+
+        AlertDialogFragment.newInstance(
+            context.getString(R.string.title_upgrade_error),
+            context.getString(errorResId),
+            context.getString(positiveBtnResId),
+            { dialog, which ->
+                retryListener?.onClick(dialog, which).also {
+                    iapAnalytics.trackIAPEvent(
+                        eventName = Analytics.Events.IAP_ERROR_ALERT_ACTION,
+                        errorMsg = feedbackErrorMessage,
+                        actionTaken = actionTaken
+                    )
+                } ?: run { trackAlertCloseEvent(feedbackErrorMessage) }
+            },
+            context.getString(if (retryListener != null) R.string.label_cancel else R.string.label_get_help),
+            { _, _ ->
+                if (retryListener != null) {
+                    trackAlertCloseEvent(feedbackErrorMessage)
+                    if (context is DialogFragment) context.dismiss()
+                } else {
+                    showFeedbackScreen(context, feedbackErrorMessage)
+                }
+            }, false
+        ).show(context.childFragmentManager, null)
+    }
+
+    /**
+     * Shows Alert Dialog for all error cases that can occur after a successful course purchase i.e
+     * Course already purchased (Basket-API) or unable to verify the purchase on backend
+     * (Execute-API).
+     *
+     * Course Already Purchased : Three buttons; Refresh Now, Get help and Cancel, with two
+     * listeners. One for refresh and the other one for Get help and Cancel
+     * Unable to Verify: Three buttons; Refresh to retry, Get help and Cancel, with two listeners.
+     * One for Refresh to retry and the other one for Get Help and Cancel
+     *
+     * Events are also tracked on interaction with the alert.
+     *
+     * @param context Fragment context for resolving message strings and displaying the dialog
+     * @param errorMessage API error response for feedback message
+     * @param retryListener Retry listener to fetch the upgraded course again or to verify the
+     * purchase
+     * @param cancelListener Cancel listener to reset the purchase flow
+     */
+    private fun showPostUpgradeErrorDialog(
+        context: Fragment,
+        errorMessage: ErrorMessage = ErrorMessage(0, InAppPurchasesException()),
+        retryListener: DialogInterface.OnClickListener? = null,
+        cancelListener: DialogInterface.OnClickListener? = null
+    ) {
+
+        val feedbackErrorMessage: String = TextUtils.getFormattedErrorMessage(
+            errorMessage.requestType,
+            errorMessage.getHttpErrorCode(),
+            errorMessage.getErrorMessage()
+        ).toString()
+
+        iapAnalytics.trackIAPEvent(
+            eventName = Analytics.Events.IAP_COURSE_UPGRADE_ERROR,
+            errorMsg = feedbackErrorMessage
+        )
+        AlertDialogFragment.newInstance(
+            context.getString(R.string.title_upgrade_error),
+            context.getString(R.string.error_course_not_fullfilled),
+            context.getString(
+                if (HttpStatus.NOT_ACCEPTABLE == errorMessage.getHttpErrorCode()) R.string.label_refresh_now
+                else R.string.label_refresh_to_retry
+            ),
+            { dialog, which ->
+                retryListener?.onClick(dialog, which).also {
+                    if (HttpStatus.NOT_ACCEPTABLE == errorMessage.getHttpErrorCode()) {
+                        // Add Analytics for refresh course on unfulfilled payments
+                    } else {
+                        iapAnalytics.initRefreshContentTime()
+                        iapAnalytics.trackIAPEvent(
+                            eventName = Analytics.Events.IAP_ERROR_ALERT_ACTION,
+                            errorMsg = feedbackErrorMessage,
+                            actionTaken = Analytics.Values.ACTION_REFRESH
+                        )
+                    }
+                }
+            },
+            context.getString(R.string.label_get_help),
+            { dialog, which ->
+                cancelListener?.onClick(dialog, which).also {
+                    showFeedbackScreen(context, feedbackErrorMessage)
+                }
+            },
+            context.getString(R.string.label_cancel),
+            { dialog, which ->
+                cancelListener?.onClick(dialog, which).also {
+                    trackAlertCloseEvent(feedbackErrorMessage)
+                }
+            }, false
+        ).show(context.childFragmentManager, null)
+    }
+
+    private fun trackAlertCloseEvent(feedbackErrorMessage: String) {
+        iapAnalytics.trackIAPEvent(
+            eventName = Analytics.Events.IAP_ERROR_ALERT_ACTION,
+            errorMsg = feedbackErrorMessage,
+            actionTaken = Analytics.Values.ACTION_CLOSE
+        )
+    }
+
+    private fun showFeedbackScreen(context: Fragment, feedbackErrorMessage: String) {
+        environment.router?.showFeedbackScreen(
+            context.requireActivity(),
+            context.getString(R.string.email_subject_upgrade_error),
+            feedbackErrorMessage
+        )
+        iapAnalytics.trackIAPEvent(
+            eventName = Analytics.Events.IAP_ERROR_ALERT_ACTION,
+            errorMsg = feedbackErrorMessage,
+            actionTaken = Analytics.Values.ACTION_GET_HELP
+        )
+    }
+
+    fun showNewExperienceAlertDialog(
+        fragment: Fragment,
+        onPositiveClick: DialogInterface.OnClickListener,
+        onNegativeClick: DialogInterface.OnClickListener
+    ) {
+        AlertDialogFragment.newInstance(
+            fragment.getString(R.string.silent_course_upgrade_success_title),
+            fragment.getString(R.string.silent_course_upgrade_success_message),
+            fragment.getString(R.string.label_refresh_now),
+            onPositiveClick,
+            fragment.getString(R.string.label_continue_without_update),
+            onNegativeClick,
+            false
+        ).show(fragment.childFragmentManager, null)
+    }
+
+    /**
+     * Method used to display the dialog after completing the Un fulfilled purchases flow.
+     *
+     * @param fragment context of the screen dialog is display for
+     * */
+    fun showNoUnFulfilledPurchasesDialog(fragment: Fragment) {
+        AlertDialogFragment.newInstance(
+            fragment.getString(R.string.title_purchases_restored),
+            fragment.getString(R.string.message_purchases_restored),
+            fragment.getString(R.string.label_close),
+            null,
+            fragment.getString(R.string.label_get_help),
+        ) { _, _ ->
+            environment.router?.showFeedbackScreen(
+                fragment.requireActivity(),
+                fragment.getString(R.string.email_subject_upgrade_error)
+            )
+        }.show(fragment.childFragmentManager, null)
+    }
+}


### PR DESCRIPTION
fixes: LEARNER-9038

### Description

[LEARNER-9038](https://2u-internal.atlassian.net/browse/LEARNER-9038)

- Refactor the In-App Purchases code flow, and structure.
- Reuse unfulfilled purchases code for Restore Purchase Flow

### Testing
- [ ] In-App Purchases shouldn't be changed.
- [ ] Analytics shouldn't affect.
- [ ] User can restore unfulfilled purchases from the account screen(the same flow as in MyCourses Screen).