### PR TITLE
fix: exclude some data classes from code optimization

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseService.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseService.java
@@ -2,6 +2,7 @@ package org.edx.mobile.course;
 
 import android.content.Context;
 
+import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -157,6 +158,7 @@ public interface CourseService {
     @POST("/api/courseware/celebration/{course_id}")
     Call<Void> updateCoursewareCelebration(@Path("course_id") final String courseId, @Body HashMap<String, Boolean> courseBody);
 
+    @Keep
     final class BlocksCompletionBody {
 
         @NonNull
@@ -179,6 +181,7 @@ public interface CourseService {
         }
     }
 
+    @Keep
     final class EnrollBody {
         @NonNull
         @SerializedName("course_details")
@@ -188,6 +191,7 @@ public interface CourseService {
             courseDetails = new CourseDetails(courseId, emailOptIn);
         }
 
+        @Keep
         private static class CourseDetails {
             @NonNull
             @SerializedName("course_id")

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/discussion/DiscussionService.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/discussion/DiscussionService.java
@@ -18,6 +18,7 @@ package org.edx.mobile.discussion;
 
 import static org.edx.mobile.http.constants.ApiConstants.PARAM_PAGE_SIZE;
 
+import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 
 import com.google.gson.annotations.SerializedName;
@@ -165,6 +166,7 @@ public interface DiscussionService {
     @POST("/api/discussion/v1/comments/")
     Call<DiscussionComment> createComment(@Body CommentBody commentBody);
 
+    @Keep
     final class FlagBody {
         @SerializedName("abuse_flagged")
         private boolean abuseFlagged;
@@ -174,6 +176,7 @@ public interface DiscussionService {
         }
     }
 
+    @Keep
     final class VoteBody {
         @SerializedName("voted")
         private boolean voted;
@@ -183,6 +186,7 @@ public interface DiscussionService {
         }
     }
 
+    @Keep
     final class FollowBody {
         @SerializedName("following")
         private boolean following;
@@ -192,6 +196,7 @@ public interface DiscussionService {
         }
     }
 
+    @Keep
     final class ReadBody {
         @SerializedName("read")
         private boolean read;


### PR DESCRIPTION
### Description

[LEARNER-9113](https://2u-internal.atlassian.net/browse/LEARNER-9113)
[LEARNER-9115](https://2u-internal.atlassian.net/browse/LEARNER-9115)

- Excluded data classes from obfuscation written in API Services classes.
- After enabling the Pro-guard, we moved all the data classes into a single package but some data classes are written inside API Services, which somehow missed while implementation. Due to this some of the app functionality wasn't working properly. 
- Classes includes 
   1. EnrollBody
   2. CourseDetails
   3. BlocksCompletionBody
   4. FlagBody
   5. VoteBody
   6. FollowBody
   7. ReadBody