### PR TITLE
fix: set default title of topics having empty names

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/discussion/DiscussionTopic.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/discussion/DiscussionTopic.java
@@ -16,10 +16,15 @@
 
 package org.edx.mobile.model.discussion;
 
+import android.content.res.Resources;
+import android.text.TextUtils;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.gson.annotations.SerializedName;
+
+import org.edx.mobile.R;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -58,6 +63,10 @@ public class DiscussionTopic implements Serializable {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getTopicTitle(Resources resources) {
+        return TextUtils.isEmpty(name) ? resources.getString(R.string.untitled_block) : name;
     }
 
     public String getThreadListUrl() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
@@ -124,7 +124,7 @@ public class CourseDiscussionPostsThreadFragment extends CourseDiscussionPostsBa
             // Either we are coming from a deep link or courseware's inline discussion
             fetchDiscussionTopic();
         } else {
-            requireActivity().setTitle(discussionTopic.getName());
+            requireActivity().setTitle(discussionTopic.getTopicTitle(getResources()));
             trackScreenView();
         }
 
@@ -205,7 +205,7 @@ public class CourseDiscussionPostsThreadFragment extends CourseDiscussionPostsBa
                         discussionTopic = courseTopics.getCoursewareTopics().get(0).getChildren().get(0);
                         if (!requireArguments().getBoolean(ARG_DISCUSSION_HAS_TOPIC_NAME)) {
                             // We only need to set the title here when coming from a deep link
-                            activity.setTitle(discussionTopic.getName());
+                            activity.setTitle(discussionTopic.getTopicTitle(getResources()));
                         }
 
                         if (getView() != null) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/DiscussionTopicsAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/DiscussionTopicsAdapter.java
@@ -28,7 +28,7 @@ public class DiscussionTopicsAdapter extends BaseListAdapter<DiscussionTopicDept
     @Override
     public void render(BaseViewHolder tag, DiscussionTopicDepth discussionTopic) {
         ViewHolder holder = (ViewHolder) tag;
-        holder.discussionTopicNameTextView.setText(discussionTopic.getDiscussionTopic().getName());
+        holder.discussionTopicNameTextView.setText(discussionTopic.getDiscussionTopic().getTopicTitle(getContext().getResources()));
         ViewCompat.setPaddingRelative(holder.discussionTopicNameTextView, childPadding * (1 + discussionTopic.getDepth()), childPadding, childPadding, childPadding);
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/TopicSpinnerAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/TopicSpinnerAdapter.java
@@ -1,14 +1,15 @@
 package org.edx.mobile.view.adapters;
 
 import android.content.Context;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.core.view.ViewCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.view.ViewCompat;
 
 import org.edx.mobile.R;
 import org.edx.mobile.model.discussion.DiscussionTopic;
@@ -39,7 +40,7 @@ public class TopicSpinnerAdapter extends ArrayAdapter<DiscussionTopicDepth> {
         final DiscussionTopicDepth topic = getItem(position);
         view.setText(ResourceUtil.getFormattedString(getContext().getResources(),
                 R.string.discussion_add_post_topic_selection, "topic",
-                topic.getDiscussionTopic().getName()));
+                topic.getDiscussionTopic().getTopicTitle(getContext().getResources())));
         return view;
     }
 
@@ -55,7 +56,7 @@ public class TopicSpinnerAdapter extends ArrayAdapter<DiscussionTopicDepth> {
         final int extraLeftPadding = topic.getDepth() * extraPaddingPerLevel;
         ViewCompat.setPaddingRelative(view, basePadding + extraLeftPadding, view.getPaddingTop(),
                 basePadding, view.getPaddingBottom());
-        view.setText(topic.getDiscussionTopic().getName());
+        view.setText(topic.getDiscussionTopic().getTopicTitle(getContext().getResources()));
         view.setEnabled(isEnabled(position));
         return view;
     }


### PR DESCRIPTION
### Description

[LEARNER-9114](https://2u-internal.atlassian.net/browse/LEARNER-9114)

- Set the topics title `Untitled` in case the name is empty or null