### PR TITLE
fix: Put Upgrade Button behind `value_prop_enabled` flag

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/EnrolledCoursesResponse.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/EnrolledCoursesResponse.kt
@@ -41,6 +41,9 @@ data class EnrolledCoursesResponse(
             EnrollmentMode.VERIFIED.name.equals(item.slug, ignoreCase = true)
         }?.androidSku.takeUnless { it.isNullOrEmpty() }
 
+    val isAuditMode: Boolean
+        get() = EnrollmentMode.AUDIT.toString().equals(mode, ignoreCase = true)
+
     override fun isChapter(): Boolean {
         return false
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -299,7 +299,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
     }
 
     private void initInAppPurchaseSetup() {
-        if (courseData.getMode().equalsIgnoreCase(EnrollmentMode.AUDIT.toString()) && !isVideoMode) {
+        if (courseData.isAuditMode() && !isVideoMode) {
             initFullscreenLoader();
             initInAppPurchaseObserver();
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.kt
@@ -399,7 +399,6 @@ class MyCoursesListFragment : OfflineSupportBaseFragment(), RefreshListener {
     ) {
         if (data.isNotEmpty()) {
             adapter.setItems(data)
-            adapter.setValuePropEnabled(environment.appFeaturesPrefs.isValuePropEnabled())
         }
 
         addFindCoursesFooter()

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseCardViewHolder.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseCardViewHolder.java
@@ -13,7 +13,6 @@ import com.bumptech.glide.Glide;
 
 import org.edx.mobile.R;
 import org.edx.mobile.model.api.CourseEntry;
-import org.edx.mobile.model.course.EnrollmentMode;
 import org.edx.mobile.util.images.ImageUtils;
 import org.edx.mobile.util.images.TopAnchorFillWidthTransformation;
 
@@ -71,11 +70,11 @@ public class CourseCardViewHolder extends BaseListAdapter.BaseViewHolder {
 
     public void setHasUpgradeOption(
             boolean isCourseEnded,
-            String mode,
+            boolean isAuditMode,
             boolean isValuePropEnabled,
             View.OnClickListener onValuePropClick
     ) {
-        if (isValuePropEnabled && !isCourseEnded && EnrollmentMode.AUDIT.toString().equalsIgnoreCase(mode)) {
+        if (!isCourseEnded && isAuditMode && isValuePropEnabled) {
             propContainer.setVisibility(View.VISIBLE);
             propContainer.setOnClickListener(onValuePropClick);
         } else {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseOutlineAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseOutlineAdapter.java
@@ -32,7 +32,6 @@ import org.edx.mobile.model.course.BlockPath;
 import org.edx.mobile.model.course.BlockType;
 import org.edx.mobile.model.course.CourseComponent;
 import org.edx.mobile.model.course.DiscussionBlockModel;
-import org.edx.mobile.model.course.EnrollmentMode;
 import org.edx.mobile.model.course.HasDownloadEntry;
 import org.edx.mobile.model.course.IBlock;
 import org.edx.mobile.model.course.VideoBlockModel;
@@ -366,8 +365,7 @@ public class CourseOutlineAdapter extends BaseAdapter {
         }
 
         if (isDenialFeatureBasedEnrolments) {
-            if (environment.getAppFeaturesPrefs().isValuePropEnabled() &&
-                    EnrollmentMode.AUDIT.toString().equalsIgnoreCase(courseData.getMode())) {
+            if (environment.getAppFeaturesPrefs().isValuePropEnabled() && courseData.isAuditMode()) {
                 viewHolder.rowSubtitle.setText(org.edx.mobile.util.TextUtils.underline(
                         context,
                         R.string.course_modal_unlock_graded_assignment
@@ -632,19 +630,21 @@ public class CourseOutlineAdapter extends BaseAdapter {
         final View upgradeBtn = view.findViewById(R.id.layout_upgrade_btn);
         final MaterialButton upgradeBtnText = upgradeBtn.findViewById(R.id.btn_upgrade);
 
-        ((ShimmerFrameLayout) upgradeBtn).hideShimmer();
-        upgradeBtn.setVisibility(courseData.getMode().equalsIgnoreCase(EnrollmentMode.AUDIT
-                .toString()) ? View.VISIBLE : View.GONE);
-
-        upgradeBtnText.setOnClickListener(view1 -> CourseModalDialogFragment.newInstance(
-                        Analytics.Screens.PLS_COURSE_DASHBOARD,
-                        courseData.getCourseId(),
-                        courseData.getCourseSku(),
-                        courseData.getCourse().getName(),
-                        courseData.getCourse().isSelfPaced())
-                .show(((AppCompatActivity) context).getSupportFragmentManager(),
-                        CourseModalDialogFragment.TAG));
-        upgradeBtnText.setText(R.string.value_prop_course_card_message);
+        if (courseData.isAuditMode() && environment.getAppFeaturesPrefs().isValuePropEnabled()) {
+            upgradeBtn.setVisibility(View.VISIBLE);
+            ((ShimmerFrameLayout) upgradeBtn).hideShimmer();
+            upgradeBtnText.setOnClickListener(view1 -> CourseModalDialogFragment.newInstance(
+                            Analytics.Screens.PLS_COURSE_DASHBOARD,
+                            courseData.getCourseId(),
+                            courseData.getCourseSku(),
+                            courseData.getCourse().getName(),
+                            courseData.getCourse().isSelfPaced())
+                    .show(((AppCompatActivity) context).getSupportFragmentManager(),
+                            CourseModalDialogFragment.TAG));
+            upgradeBtnText.setText(R.string.value_prop_course_card_message);
+        } else {
+            upgradeBtn.setVisibility(View.GONE);
+        }
 
         // Full course name should appear on the course's dashboard screen.
         courseTextName.setEllipsize(null);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/MyCoursesAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/MyCoursesAdapter.java
@@ -15,15 +15,10 @@ import org.edx.mobile.util.images.CourseCardUtils;
 
 public abstract class MyCoursesAdapter extends BaseListAdapter<EnrolledCoursesResponse> {
     private long lastClickTime;
-    private boolean isValuePropEnabled = false;
 
     public MyCoursesAdapter(Context context, IEdxEnvironment environment) {
         super(context, CourseCardViewHolder.LAYOUT, environment);
         lastClickTime = 0;
-    }
-
-    public void setValuePropEnabled(boolean isEnabled) {
-        isValuePropEnabled = isEnabled;
     }
 
     @SuppressLint("SimpleDateFormat")
@@ -34,7 +29,8 @@ public abstract class MyCoursesAdapter extends BaseListAdapter<EnrolledCoursesRe
         final CourseEntry courseData = enrollment.getCourse();
         holder.setCourseTitle(courseData.getName());
         holder.setCourseImage(courseData.getCourse_image(environment.getConfig().getApiHostURL()));
-        holder.setHasUpgradeOption(courseData.isEnded(), enrollment.getMode(), isValuePropEnabled,
+        holder.setHasUpgradeOption(courseData.isEnded(), enrollment.isAuditMode(),
+                environment.getAppFeaturesPrefs().isValuePropEnabled(),
                 v -> onValuePropClicked(enrollment));
 
         if (enrollment.getCourse().hasUpdates()) {


### PR DESCRIPTION
### Description

[LEARNER-9099](https://2u-internal.atlassian.net/browse/LEARNER-9099)

Set the `value_prop_enabled` flag to `false`:

- [x] Value Prop on My Courses screen should be hidden
- [x] Upgrade button on My Course Dashboard should be hidden
- [x] Upgradeable components should have a subtext as `Not available on Mobile`

Set the `value_prop_enabled` flag to `true`:

- [x] Value Prop on My Courses screen should be visible
- [x] Value Prop should be hidden for an expired course on the My Courses screen
- [x] Value Prop should be hidden for a Verified course on the My Courses screen
- [x] Upgrade button on My Course Dashboard should be visible
- [x] Upgrade button should be hidden for an expired course on the Course Dashboard
- [x] Upgrade button should be hidden for a Verified course on the Course Dashboard
- [x] Upgradeable components should have a subtext as `Unlock graded assignments`
