### PR TITLE
fix: Handle Null Pointer Exception in AppFeaturesPrefs

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/AppFeaturesPrefs.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/AppFeaturesPrefs.kt
@@ -18,7 +18,9 @@ class AppFeaturesPrefs @Inject constructor(@ApplicationContext context: Context)
     }
 
     private fun getAppConfig(): AppConfig {
-        return Gson().fromJson(pref.getString(PrefManager.Key.APP_CONFIG), AppConfig::class.java)
+        return pref.getString(PrefManager.Key.APP_CONFIG)?.let {
+            Gson().fromJson(it, AppConfig::class.java)
+        } ?: AppConfig()
     }
 
     private fun getIAPConfig() = getAppConfig().iapConfig


### PR DESCRIPTION

### Description

[LEARNER-9126](https://2u-internal.atlassian.net/browse/LEARNER-9126)

- Handle NullPointerException while accessing AppConfig from SharedPreference.