### PR TITLE
Fix: Braze initialization through Segment at Runtime

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/MainApplication.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/MainApplication.java
@@ -11,7 +11,6 @@ import androidx.annotation.NonNull;
 import androidx.multidex.MultiDexApplication;
 
 import com.appboy.Appboy;
-import com.appboy.AppboyLifecycleCallbackListener;
 import com.appboy.configuration.AppboyConfig;
 import com.facebook.FacebookSdk;
 import com.google.firebase.FirebaseApp;
@@ -154,7 +153,6 @@ public abstract class MainApplication extends MultiDexApplication {
                     .setHandlePushDeepLinksAutomatically(true)
                     .build();
             Appboy.configure(this, appboyConfig);
-            registerActivityLifecycleCallbacks(new AppboyLifecycleCallbackListener(true, true));
         }
     }
 


### PR DESCRIPTION
### Description

[LEARNER-9046](https://2u-internal.atlassian.net/browse/LEARNER-9046)

Since the SDK needs to be dynamically initialized with an API key at runtime in the Segment/Braze integration, we actually shouldn't use registerActivityLifecycleCallbacks() at all. Doing so will set up lifecycle listeners that will inappropriately initialize the SDK automatically upon certain app lifecycle events. This isn't good because in the Segment/Braze integration, we can't safely initialize the SDK (which happens upon any call to getInstance()) until Segment is able to configure the SDK with an API key at runtime.

Reference: https://github.com/Appboy/appboy-segment-android/issues/33