### PR TITLE
fix: enable mapping file upload to firebaseCrashlytics

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -500,6 +500,11 @@ android {
         release {
             minifyEnabled true
             shrinkResources true
+            if (firebaseEnabled ?: false) {
+                firebaseCrashlytics {
+                    mappingFileUploadEnabled true
+                }
+            }
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             // Only apply release signing configurations if keystore.properties is available
             if (project.file('signing/keystore.properties').exists()) {


### PR DESCRIPTION
### Description

[LEARNER-9130](https://2u-internal.atlassian.net/browse/LEARNER-9130)

- enable readable crash reports in the Crashlytics dashboard by uploading mapping file