### PR TITLE
fix: In-app purchases success/error flow issues

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/event/IAPFlowEvent.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/event/IAPFlowEvent.kt
@@ -1,0 +1,8 @@
+package org.edx.mobile.event
+
+import org.edx.mobile.model.iap.IAPFlowData
+
+class IAPFlowEvent(
+    val flowAction: IAPFlowData.IAPAction,
+    val iapFlowData: IAPFlowData? = null
+) : BaseEvent()

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/exception/ErrorMessage.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/exception/ErrorMessage.kt
@@ -25,6 +25,12 @@ data class ErrorMessage(
         const val PRICE_CODE = 0x206
     }
 
+    private fun isPreUpgradeErrorType(): Boolean = requestType == PRICE_CODE ||
+            requestType == ADD_TO_BASKET_CODE || requestType == CHECKOUT_CODE ||
+            requestType == PAYMENT_SDK_CODE
+
+    fun isPostUpgradeErrorType(): Boolean = !isPreUpgradeErrorType()
+
     fun getHttpErrorCode(): Int {
         if (throwable is InAppPurchasesException) {
             return throwable.httpErrorCode
@@ -42,6 +48,8 @@ data class ErrorMessage(
     }
 
     fun canRetry(): Boolean {
-        return requestType == PRICE_CODE
+        return requestType == PRICE_CODE ||
+                requestType == EXECUTE_ORDER_CODE ||
+                requestType == COURSE_REFRESH_CODE
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/BillingProcessor.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/BillingProcessor.kt
@@ -15,13 +15,11 @@ import com.android.billingclient.api.PurchasesUpdatedListener
 import com.android.billingclient.api.SkuDetails
 import com.android.billingclient.api.SkuDetailsParams
 import com.android.billingclient.api.SkuDetailsResponseListener
-import dagger.Module
-import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ActivityComponent
 import dagger.hilt.android.qualifiers.ApplicationContext
 import org.edx.mobile.extenstion.encodeToString
 import org.edx.mobile.logger.Logger
 import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * The BillingProcessor implements all billing functionality for application.
@@ -32,8 +30,7 @@ import javax.inject.Inject
  *
  * Inspiration: [https://github.com/android/play-billing-samples/blob/master/TrivialDriveKotlin/app/src/main/java/com/sample/android/trivialdrivesample/billing/BillingDataSource.kt]
  * */
-@Module
-@InstallIn(ActivityComponent::class)
+@Singleton
 class BillingProcessor @Inject constructor(@ApplicationContext val context: Context) :
     PurchasesUpdatedListener, BillingClientStateListener {
 
@@ -206,13 +203,6 @@ class BillingProcessor @Inject constructor(@ApplicationContext val context: Cont
 
     fun isConnected(): Boolean {
         return billingClient.isReady
-    }
-
-    /**
-     * Closes the connection and releases all held resources such as service connections.
-     */
-    fun disconnect() {
-        billingClient.endConnection()
     }
 
     companion object {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/EnrollmentResponse.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/EnrollmentResponse.kt
@@ -4,7 +4,6 @@ import com.google.gson.*
 import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
 import org.edx.mobile.logger.Logger
-import org.edx.mobile.model.course.EnrollmentMode
 import java.io.Serializable
 import java.lang.reflect.Type
 
@@ -70,6 +69,8 @@ data class EnrollmentResponse(
  * @return the list of all audit courses SKUs.
  */
 fun List<EnrolledCoursesResponse>.getAuditCoursesSku(): List<String> {
-    return this.filter { EnrollmentMode.AUDIT.toString().equals(it.mode, true) }
-        .mapNotNull { it.courseSku }.toList()
+    return this
+        .filter { it.isAuditMode }
+        .mapNotNull { it.courseSku }
+        .toList()
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/iap/IAPFlowData.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/iap/IAPFlowData.kt
@@ -1,0 +1,31 @@
+package org.edx.mobile.model.iap
+
+import java.io.Serializable
+
+data class IAPFlowData(
+    var upgradeMode: UpgradeMode = UpgradeMode.NORMAL,
+    var productId: String = "",
+    var basketId: Long = 0,
+    var purchaseToken: String = "",
+    var isVerificationPending: Boolean = false
+) : Serializable {
+    fun clear() {
+        upgradeMode = UpgradeMode.NORMAL
+        productId = ""
+        basketId = 0
+        purchaseToken = ""
+        isVerificationPending = false
+    }
+
+    enum class UpgradeMode {
+        NORMAL,
+        SILENT;
+
+        fun isSilentMode() = this == SILENT
+    }
+
+    enum class IAPAction {
+        SHOW_FULL_SCREEN_LOADER,
+        PURCHASE_FLOW_COMPLETE
+    }
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/InAppPurchasesUtils.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/InAppPurchasesUtils.kt
@@ -2,11 +2,9 @@ package org.edx.mobile.util
 
 import org.edx.mobile.R
 import org.edx.mobile.exception.ErrorMessage
+import org.edx.mobile.http.HttpStatus
 
 object InAppPurchasesUtils {
-
-    val postPurchasedRequests =
-        listOf(ErrorMessage.EXECUTE_ORDER_CODE, ErrorMessage.COURSE_REFRESH_CODE)
 
     /**
      * Method to filter the incomplete purchases for the given enrolled audit course and already paid
@@ -29,17 +27,17 @@ object InAppPurchasesUtils {
      * */
     fun getErrorMessage(requestType: Int, httpErrorCode: Int) =
         when (httpErrorCode) {
-            400 -> when (requestType) {
+            HttpStatus.BAD_REQUEST -> when (requestType) {
                 ErrorMessage.ADD_TO_BASKET_CODE -> R.string.error_course_not_found
                 ErrorMessage.CHECKOUT_CODE -> R.string.error_payment_not_processed
                 ErrorMessage.EXECUTE_ORDER_CODE -> R.string.error_course_not_fullfilled
                 else -> R.string.general_error_message
             }
-            403 -> when (requestType) {
+            HttpStatus.FORBIDDEN -> when (requestType) {
                 ErrorMessage.EXECUTE_ORDER_CODE -> R.string.error_course_not_fullfilled
                 else -> R.string.error_user_not_authenticated
             }
-            406 -> R.string.error_course_already_paid
+            HttpStatus.NOT_ACCEPTABLE -> R.string.error_course_already_paid
             else -> when (requestType) {
                 ErrorMessage.PAYMENT_SDK_CODE -> R.string.error_payment_not_processed
                 ErrorMessage.PRICE_CODE -> R.string.error_price_not_fetched

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/observer/Event.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/observer/Event.kt
@@ -1,0 +1,28 @@
+package org.edx.mobile.util.observer
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Used as a wrapper for data that is exposed via a LiveData that represents an event.
+ * The advantage of this approach is that the user needs to specify the intention by using
+ * [Event.getContentIfNotConsumed] or [Event.peekContent]. This method models the events as part of
+ * the state: they’re now simply a message that has been consumed or not.
+ *
+ * Inspiration: https://medium.com/androiddevelopers/ac2622673150
+ */
+open class Event<out T>(private val content: T) {
+
+    private val isConsumed = AtomicBoolean(false)
+
+    /**
+     * Returns the content and prevents its use again.
+     */
+    fun getContentIfNotConsumed(): T? =
+        if (isConsumed.compareAndSet(false, true)) content
+        else null
+
+    /**
+     * Returns the content, even if it's already been consumed..
+     */
+    fun peekContent(): T = content
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/observer/EventObserver.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/observer/EventObserver.kt
@@ -1,0 +1,20 @@
+package org.edx.mobile.util.observer
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+
+/**
+ * A non-nullable observer for [Event] class that returns the value of the event if it is not yet
+ * consumed.
+ *
+ * Inspiration: https://gist.github.com/JoseAlcerreca/e0bba240d9b3cffa258777f12e5c0ae9
+ */
+class EventObserver<T>(private val consumer: (T) -> Unit) : Observer<Event<T>> {
+    override fun onChanged(event: Event<T>?) {
+        consumer(event?.getContentIfNotConsumed() ?: return)
+    }
+}
+
+fun <T> MutableLiveData<Event<T>>.postEvent(content: T) {
+    postValue(Event(content))
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/TabsBaseFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/TabsBaseFragment.java
@@ -190,17 +190,6 @@ public abstract class TabsBaseFragment extends BaseFragment {
         if (fragmentItems.size() - 1 > 1) {
             binding.viewPager2.setOffscreenPageLimit(fragmentItems.size() - 1);
         }
-        /*
-         ViewPager doesn't call the onPageSelected for its first item, so we have to explicitly
-         call it ourselves.
-         Inspiration for this solution: https://stackoverflow.com/a/16074152/1402616
-         */
-        binding.viewPager2.post(new Runnable() {
-            @Override
-            public void run() {
-                pageChangeListener.onPageSelected(binding.viewPager2.getCurrentItem());
-            }
-        });
     }
 
     protected void createTab(@NonNull TabLayout.Tab tab, @NonNull FragmentItemModel fragmentItem) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/CourseDateViewModel.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/CourseDateViewModel.kt
@@ -18,7 +18,7 @@ import org.edx.mobile.model.course.CourseDates
 import org.edx.mobile.model.course.ResetCourseDates
 import org.edx.mobile.repository.CourseDatesRepository
 import org.edx.mobile.util.CalendarUtils
-import java.util.*
+import java.util.Calendar
 import javax.inject.Inject
 
 @HiltViewModel

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/CourseViewModel.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/CourseViewModel.kt
@@ -12,6 +12,8 @@ import org.edx.mobile.model.api.EnrolledCoursesResponse
 import org.edx.mobile.model.api.EnrollmentResponse
 import org.edx.mobile.module.db.DataCallback
 import org.edx.mobile.repository.CourseRepository
+import org.edx.mobile.util.observer.Event
+import org.edx.mobile.util.observer.postEvent
 import org.edx.mobile.viewModel.CourseViewModel.CoursesRequestType.CACHE
 import org.edx.mobile.viewModel.CourseViewModel.CoursesRequestType.STALE
 import javax.inject.Inject
@@ -24,8 +26,8 @@ class CourseViewModel @Inject constructor(
 
     private val logger: Logger = Logger(CourseViewModel::class.java.simpleName)
 
-    private val _enrolledCourses = MutableLiveData<List<EnrolledCoursesResponse>>()
-    val enrolledCoursesResponse: LiveData<List<EnrolledCoursesResponse>> = _enrolledCourses
+    private val _enrolledCourses = MutableLiveData<Event<List<EnrolledCoursesResponse>>>()
+    val enrolledCoursesResponse: LiveData<Event<List<EnrolledCoursesResponse>>> = _enrolledCourses
 
     private val _showProgress = MutableLiveData(true)
     val showProgress: LiveData<Boolean> = _showProgress
@@ -44,7 +46,7 @@ class CourseViewModel @Inject constructor(
 
                 override fun onSuccess(result: Result.Success<EnrollmentResponse>) {
                     result.data?.let {
-                        _enrolledCourses.postValue(it.enrollments)
+                        _enrolledCourses.postEvent(it.enrollments)
                         environment.appFeaturesPrefs.setAppConfig(it.appConfig)
 
                         if (type != CACHE) {


### PR DESCRIPTION
### Description

[LEARNER-9142](https://2u-internal.atlassian.net/browse/LEARNER-9142)

- Fix the price load issue for the courses even if SKU is not available.
- Fix overlapping dialogs by adding consumable observables for live data.
- Remove activity parameter passing approach to InAppPurchasesViewModel.
- Remove the shared ViewModel approach and restrict to execution of multiple iap-flows and communicating data through
event-bus between activities and fragments.
- Verify and fix the issue for restore/unfulfilled purchases flow.