### PR TITLE
Fix: Update Braze SDK version to support Android S+ devices

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -220,7 +220,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.5.0-alpha02'
 
     // Braze SDK Integration
-    implementation 'com.appboy:appboy-segment-integration:7.0.0'
+    implementation 'com.appboy:appboy-segment-integration:14.0.0'
 
     // test project configuration
     testImplementation 'junit:junit:4.12'
@@ -540,6 +540,12 @@ android {
     }
 
     kotlinOptions {
+        /**
+         * Braze may cause a compiler warning about "Inheritance from an interface with
+         * '@JvmDefault' members" without this flag.
+         * Ref: https://github.com/Appboy/appboy-android-sdk/blob/master/CHANGELOG.md#important-2
+         */
+        freeCompilerArgs = ['-Xjvm-default=all']
         jvmTarget = "11"
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/MainApplication.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/MainApplication.java
@@ -10,8 +10,8 @@ import android.os.Handler;
 import androidx.annotation.NonNull;
 import androidx.multidex.MultiDexApplication;
 
-import com.appboy.Appboy;
-import com.appboy.configuration.AppboyConfig;
+import com.braze.Braze;
+import com.braze.configuration.BrazeConfig;
 import com.facebook.FacebookSdk;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.crashlytics.FirebaseCrashlytics;
@@ -146,13 +146,14 @@ public abstract class MainApplication extends MultiDexApplication {
 
         // Braze SDK Initialization
         if (config.getBrazeConfig().isEnabled() && config.getFirebaseConfig().isEnabled()) {
-            AppboyConfig appboyConfig = new AppboyConfig.Builder()
+            BrazeConfig brazeConfig = new BrazeConfig.Builder()
                     .setIsFirebaseCloudMessagingRegistrationEnabled(config.areFirebasePushNotificationsEnabled()
                             && config.getBrazeConfig().isPushNotificationsEnabled())
                     .setFirebaseCloudMessagingSenderIdKey(config.getFirebaseConfig().getProjectNumber())
                     .setHandlePushDeepLinksAutomatically(true)
+                    .setIsFirebaseMessagingServiceOnNewTokenRegistrationEnabled(true)
                     .build();
-            Appboy.configure(this, appboyConfig);
+            Braze.configure(this, brazeConfig);
         }
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/notifications/services/NotificationService.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/notifications/services/NotificationService.java
@@ -1,6 +1,6 @@
 package org.edx.mobile.notifications.services;
 
-import com.appboy.AppboyFirebaseMessagingService;
+import com.braze.push.BrazeFirebaseMessagingService;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
@@ -23,8 +23,8 @@ public class NotificationService extends FirebaseMessagingService {
         final IEdxEnvironment environment = MainApplication.getEnvironment(this);
 
         if (environment.getConfig().areFirebasePushNotificationsEnabled()) {
-            if (AppboyFirebaseMessagingService.isBrazePushNotification(remoteMessage)) {
-                AppboyFirebaseMessagingService.handleBrazeRemoteMessage(this, remoteMessage);
+            if (BrazeFirebaseMessagingService.isBrazePushNotification(remoteMessage)) {
+                BrazeFirebaseMessagingService.handleBrazeRemoteMessage(this, remoteMessage);
             } else {
                 PushLinkManager.INSTANCE.onFCMForegroundNotificationReceived(remoteMessage);
             }

--- a/constants.gradle
+++ b/constants.gradle
@@ -3,7 +3,7 @@ project.ext {
     KOTLIN_VERSION = "1.6.10"
     GRADLE_PLUGIN_VERSION = "7.0.3"
     BUILD_TOOLS_VERSION = "30.0.2"
-    COMPILE_SDK_VERSION = 30
+    COMPILE_SDK_VERSION = 31
     // API Level that the application will target
     TARGET_SDK_VERSION = 31
     // Minimum API Level required for the application to run


### PR DESCRIPTION
Fixes: LEARNER-9198

### Description

[LEARNER-9198](https://2u-internal.atlassian.net/browse/LEARNER-9198)

Update Braze SDK version to support Android S+ devices.

### Reference
- [New Flag during initializtion](https://github.com/Appboy/appboy-android-sdk/blob/master/CHANGELOG.md#added-14)
- [Kotlin Option for build warnings](https://github.com/Appboy/appboy-android-sdk/blob/master/CHANGELOG.md#important-2)