### PR TITLE
feat: Add Project OneTrust in Profile screen

### DIFF
--- a/OpenEdXMobile/res/layout/fragment_account.xml
+++ b/OpenEdXMobile/res/layout/fragment_account.xml
@@ -231,6 +231,73 @@
                     android:background="@color/neutralXLight" />
             </LinearLayout>
 
+            <LinearLayout
+                android:id="@+id/container_privacy"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/selectable_rounded_box_overlay"
+                android:orientation="vertical"
+                android:paddingTop="@dimen/edx_default_margin"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <TextView
+                    style="@style/profile_field_heading"
+                    android:text="@string/label_privacy" />
+
+                <TextView
+                    android:id="@+id/tv_privacy_policy"
+                    style="@style/profile_field_title"
+                    android:layout_width="match_parent"
+                    android:layout_marginTop="@dimen/edx_half_margin"
+                    android:background="@drawable/selectable_rounded_box_overlay"
+                    android:gravity="center_vertical"
+                    android:paddingStart="@dimen/edx_default_margin"
+                    android:paddingEnd="@dimen/edx_default_margin"
+                    android:text="@string/label_privacy_policy"
+                    android:visibility="gone"
+                    app:drawableEndCompat="@drawable/ic_chevron_right"
+                    app:drawableTint="@color/primaryBaseColor"
+                    tools:visibility="visible" />
+
+                <TextView
+                    android:id="@+id/tv_cookie_policy"
+                    style="@style/profile_field_title"
+                    android:layout_width="match_parent"
+                    android:layout_marginTop="@dimen/edx_half_margin"
+                    android:background="@drawable/selectable_rounded_box_overlay"
+                    android:gravity="center_vertical"
+                    android:paddingStart="@dimen/edx_default_margin"
+                    android:paddingEnd="@dimen/edx_default_margin"
+                    android:text="@string/label_cookie_policy"
+                    android:visibility="gone"
+                    app:drawableEndCompat="@drawable/ic_chevron_right"
+                    app:drawableTint="@color/primaryBaseColor"
+                    tools:visibility="visible" />
+
+                <TextView
+                    android:id="@+id/tv_data_consent_policy"
+                    style="@style/profile_field_title"
+                    android:layout_width="match_parent"
+                    android:layout_marginTop="@dimen/edx_half_margin"
+                    android:background="@drawable/selectable_rounded_box_overlay"
+                    android:gravity="center_vertical"
+                    android:paddingStart="@dimen/edx_default_margin"
+                    android:paddingEnd="@dimen/edx_default_margin"
+                    android:text="@string/label_do_not_sell_my_personal_data"
+                    android:visibility="gone"
+                    app:drawableEndCompat="@drawable/ic_chevron_right"
+                    app:drawableTint="@color/primaryBaseColor"
+                    tools:visibility="visible" />
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/edx_line"
+                    android:layout_marginTop="@dimen/edx_default_margin"
+                    android:background="@color/neutralXLight" />
+
+            </LinearLayout>
+
             <TextView
                 android:id="@+id/tv_help"
                 style="@style/profile_field_heading"

--- a/OpenEdXMobile/res/layout/fragment_account.xml
+++ b/OpenEdXMobile/res/layout/fragment_account.xml
@@ -243,17 +243,19 @@
 
                 <TextView
                     style="@style/profile_field_heading"
+                    android:paddingBottom="@dimen/edx_quarter_margin"
                     android:text="@string/label_privacy" />
 
                 <TextView
                     android:id="@+id/tv_privacy_policy"
                     style="@style/profile_field_title"
                     android:layout_width="match_parent"
-                    android:layout_marginTop="@dimen/edx_half_margin"
                     android:background="@drawable/selectable_rounded_box_overlay"
                     android:gravity="center_vertical"
                     android:paddingStart="@dimen/edx_default_margin"
+                    android:paddingTop="@dimen/edx_quarter_margin"
                     android:paddingEnd="@dimen/edx_default_margin"
+                    android:paddingBottom="@dimen/edx_quarter_margin"
                     android:text="@string/label_privacy_policy"
                     android:visibility="gone"
                     app:drawableEndCompat="@drawable/ic_chevron_right"
@@ -264,11 +266,12 @@
                     android:id="@+id/tv_cookie_policy"
                     style="@style/profile_field_title"
                     android:layout_width="match_parent"
-                    android:layout_marginTop="@dimen/edx_half_margin"
                     android:background="@drawable/selectable_rounded_box_overlay"
                     android:gravity="center_vertical"
                     android:paddingStart="@dimen/edx_default_margin"
+                    android:paddingTop="@dimen/edx_quarter_margin"
                     android:paddingEnd="@dimen/edx_default_margin"
+                    android:paddingBottom="@dimen/edx_quarter_margin"
                     android:text="@string/label_cookie_policy"
                     android:visibility="gone"
                     app:drawableEndCompat="@drawable/ic_chevron_right"
@@ -279,11 +282,12 @@
                     android:id="@+id/tv_data_consent_policy"
                     style="@style/profile_field_title"
                     android:layout_width="match_parent"
-                    android:layout_marginTop="@dimen/edx_half_margin"
                     android:background="@drawable/selectable_rounded_box_overlay"
                     android:gravity="center_vertical"
                     android:paddingStart="@dimen/edx_default_margin"
+                    android:paddingTop="@dimen/edx_quarter_margin"
                     android:paddingEnd="@dimen/edx_default_margin"
+                    android:paddingBottom="@dimen/edx_quarter_margin"
                     android:text="@string/label_do_not_sell_my_personal_data"
                     android:visibility="gone"
                     app:drawableEndCompat="@drawable/ic_chevron_right"
@@ -293,7 +297,7 @@
                 <View
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/edx_line"
-                    android:layout_marginTop="@dimen/edx_default_margin"
+                    android:layout_marginTop="@dimen/widget_margin"
                     android:background="@color/neutralXLight" />
 
             </LinearLayout>
@@ -392,8 +396,8 @@
                 style="@style/profile_field_description"
                 android:layout_marginTop="@dimen/edx_default_margin"
                 android:layout_marginBottom="@dimen/edx_default_margin"
-                android:lineHeight="@dimen/edx_margin"
                 android:textSize="@dimen/edx_xx_small"
+                app:lineHeight="@dimen/edx_margin"
                 tools:text="Version X.X.X" />
 
             <LinearLayout

--- a/OpenEdXMobile/res/values/profile_strings.xml
+++ b/OpenEdXMobile/res/values/profile_strings.xml
@@ -35,7 +35,14 @@
     <string name="description_delete_account">Follow the instructions on the next screen to delete your account and all related data.</string>
     <!--  Label of App Version  -->
     <string name="label_app_version">Version</string>
-
+    <!--  Heading of Privacy Fields  -->
+    <string name="label_privacy">Privacy</string>
+    <!--  Label of Privacy Policy Button  -->
+    <string name="label_privacy_policy">Privacy policy</string>
+    <!--  Label of Cookie Policy Button  -->
+    <string name="label_cookie_policy">Cookie policy</string>
+    <!--  Label of Data Consent Button  -->
+    <string name="label_do_not_sell_my_personal_data">Do not sell my personal data</string>
     <!-- Logout button label -->
     <string name="logout">Logout</string>
     <!-- Profile screen version -->

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
@@ -886,13 +886,16 @@ public interface Analytics {
         // Profile Page Screen Events
         String SCREEN_NAVIGATION = "edx.bi.app.navigation.screen";
         String PERSONAL_INFORMATION_CLICKED = "edx.bi.app.profile.personal_info.clicked";
-        String FAQ_CLICKED = "eedx.bi.app.profile.faq.clicked";
+        String FAQ_CLICKED = "edx.bi.app.profile.faq.clicked";
         String WIFI_ON = "edx.bi.app.profile.wifi.switch.on";
         String WIFI_OFF = "edx.bi.app.profile.wifi.switch.off";
         String WIFI_ALLOW = "edx.bi.app.profile.wifi.allow";
         String WIFI_DONT_ALLOW = "edx.bi.app.profile.wifi.dont_allow";
         String EMAIL_SUPPORT_CLICKED = "edx.bi.app.profile.email_support.clicked";
         String DELETE_ACCOUNT_CLICKED = "edx.bi.app.profile.delete_account.clicked";
+        String PRIVACY_POLICY_CLICKED = "edx.bi.app.profile.privacy_policy.clicked";
+        String COOKIE_POLICY_CLICKED = "edx.bi.app.profile.cookie_policy.clicked";
+        String DO_NOT_SELL_DATA_CLICKED = "edx.bi.app.profile.do_not_sell_data.clicked";
         // Video Download Quality
         String PROFILE_VIDEO_DOWNLOAD_QUALITY_CLICKED = "edx.bi.app.profile.video_download_quality.clicked";
         String COURSE_VIDEOS_VIDEO_DOWNLOAD_QUALITY_CLICKED = "edx.bi.app.course_videos.video_download_quality.clicked";
@@ -1108,6 +1111,9 @@ public interface Analytics {
         String WIFI_DONT_ALLOW = "Wifi Dont Allow";
         String EMAIL_SUPPORT_CLICKED = "Email Support Clicked";
         String DELETE_ACCOUNT_CLICKED = "Profile: Delete Account Clicked";
+        String PRIVACY_POLICY_CLICKED = "Privacy Policy Clicked";
+        String COOKIE_POLICY_CLICKED = "Cookie Policy Clicked";
+        String DO_NOT_SELL_DATA_CLICKED = "Do Not Sell Data Clicked";
         // Video Download Quality
         String PROFILE_VIDEO_DOWNLOAD_QUALITY_CLICKED = "Profile: Video Download Quality Clicked";
         String COURSE_VIDEOS_VIDEO_DOWNLOAD_QUALITY_CLICKED = "Course Videos: Video Download Quality Clicked";

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
@@ -70,7 +70,7 @@ public class LoginPrefs {
         pref.put(PrefManager.Key.AUTH_JSON, null);
         pref.put(PrefManager.Key.VIDEO_QUALITY, VideoQuality.AUTO.ordinal());
         pref.put(PrefManager.Key.PROFILE_IMAGE, null);
-        EdxCookieManager.getSharedInstance(MainApplication.instance()).clearAllCookie();
+        EdxCookieManager.getSharedInstance(MainApplication.instance()).clearAllCookies();
     }
 
     public void saveSocialLoginToken(@NonNull String accessToken, @NonNull String backend) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
@@ -70,7 +70,7 @@ public class LoginPrefs {
         pref.put(PrefManager.Key.AUTH_JSON, null);
         pref.put(PrefManager.Key.VIDEO_QUALITY, VideoQuality.AUTO.ordinal());
         pref.put(PrefManager.Key.PROFILE_IMAGE, null);
-        EdxCookieManager.getSharedInstance(MainApplication.instance()).clearWebViewCookie(true);
+        EdxCookieManager.getSharedInstance(MainApplication.instance()).clearAllCookie();
     }
 
     public void saveSocialLoginToken(@NonNull String accessToken, @NonNull String backend) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
@@ -70,7 +70,7 @@ public class LoginPrefs {
         pref.put(PrefManager.Key.AUTH_JSON, null);
         pref.put(PrefManager.Key.VIDEO_QUALITY, VideoQuality.AUTO.ordinal());
         pref.put(PrefManager.Key.PROFILE_IMAGE, null);
-        EdxCookieManager.getSharedInstance(MainApplication.instance()).clearWebWiewCookie();
+        EdxCookieManager.getSharedInstance(MainApplication.instance()).clearWebViewCookie(true);
     }
 
     public void saveSocialLoginToken(@NonNull String accessToken, @NonNull String backend) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/services/EdxCookieManager.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/services/EdxCookieManager.java
@@ -68,15 +68,17 @@ public class EdxCookieManager {
         return instance;
     }
 
-    public void clearWebViewCookie(Boolean forceClear) {
-        String cookie = CookieManager.getInstance().getCookie(config.getApiHostURL());
-
+    public void clearAllCookie() {
         CookieManager.getInstance().removeAllCookies(null);
         authSessionCookieExpiration = -1;
+    }
 
+    public void clearAndRetainCookie() {
+        String cookie = CookieManager.getInstance().getCookie(config.getApiHostURL());
+        clearAllCookie();
         // The `edx_do_not_sell` cookie relates to the Data Sell Consent Policy and we should retain
         // it if we are only refreshing the session cookies
-        if (!forceClear && cookie != null && cookie.contains("edx_do_not_sell"))
+        if (cookie != null && cookie.contains("edx_do_not_sell"))
             setDataConsentCookie();
     }
 
@@ -87,7 +89,7 @@ public class EdxCookieManager {
                 @Override
                 public void onResponse(@NonNull final Call<RequestBody> call,
                                        @NonNull final Response<RequestBody> response) {
-                    clearWebViewCookie(false);
+                    clearAndRetainCookie();
                     final CookieManager cookieManager = CookieManager.getInstance();
                     for (Cookie cookie : Cookie.parseAll(
                             call.request().url(), response.headers())) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/services/EdxCookieManager.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/services/EdxCookieManager.java
@@ -68,14 +68,17 @@ public class EdxCookieManager {
         return instance;
     }
 
-    public void clearAllCookie() {
+    public void clearAllCookies() {
         CookieManager.getInstance().removeAllCookies(null);
         authSessionCookieExpiration = -1;
     }
 
-    public void clearAndRetainCookie() {
+    /**
+     * Clears all session cookies but retain the required cookies if available
+     */
+    public void clearAndRetainCookies() {
         String cookie = CookieManager.getInstance().getCookie(config.getApiHostURL());
-        clearAllCookie();
+        clearAllCookies();
         // The `edx_do_not_sell` cookie relates to the Data Sell Consent Policy and we should retain
         // it if we are only refreshing the session cookies
         if (cookie != null && cookie.contains("edx_do_not_sell"))
@@ -89,7 +92,7 @@ public class EdxCookieManager {
                 @Override
                 public void onResponse(@NonNull final Call<RequestBody> call,
                                        @NonNull final Response<RequestBody> response) {
-                    clearAndRetainCookie();
+                    clearAndRetainCookies();
                     final CookieManager cookieManager = CookieManager.getInstance();
                     for (Cookie cookie : Cookie.parseAll(
                             call.request().url(), response.headers())) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/services/EdxCookieManager.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/services/EdxCookieManager.java
@@ -71,7 +71,7 @@ public class EdxCookieManager {
     public void clearWebViewCookie(Boolean forceClear) {
         String cookie = CookieManager.getInstance().getCookie(config.getApiHostURL());
 
-        CookieManager.getInstance().removeAllCookie();
+        CookieManager.getInstance().removeAllCookies(null);
         authSessionCookieExpiration = -1;
 
         // The `edx_do_not_sell` cookie relates to the Data Sell Consent Policy and we should retain
@@ -83,7 +83,7 @@ public class EdxCookieManager {
     public synchronized void tryToRefreshSessionCookie() {
         if (loginCall == null || loginCall.isCanceled()) {
             loginCall = loginService.login();
-            loginCall.enqueue(new Callback<RequestBody>() {
+            loginCall.enqueue(new Callback<>() {
                 @Override
                 public void onResponse(@NonNull final Call<RequestBody> call,
                                        @NonNull final Response<RequestBody> response) {
@@ -130,6 +130,6 @@ public class EdxCookieManager {
 
     private void setDataConsentCookie() {
         CookieManager.getInstance().setCookie(config.getApiHostURL(), DATA_CONSENT_COOKIE);
-        CookieManager.getInstance().flush();
+        retainSessionCookies();
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/AgreementUrlType.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/AgreementUrlType.kt
@@ -6,16 +6,18 @@ import org.edx.mobile.R
  * This enum defines the URL type of Agreement
  */
 enum class AgreementUrlType {
-    EULA, TOS, PRIVACY_POLICY;
+    EULA, TOS, PRIVACY_POLICY, COOKIE_POLICY, DATA_CONSENT;
 
     /**
      * @return The string resource's ID if it's a valid enum inside [AgreementUrlType].
      */
-    fun getStringResId(): Int {
+    fun getStringResId(): Int? {
         return when (this) {
             EULA -> R.string.eula_file_link
             TOS -> R.string.terms_file_link
             PRIVACY_POLICY -> R.string.privacy_file_link
+            COOKIE_POLICY -> null
+            DATA_CONSENT -> null
         }
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/Config.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/Config.java
@@ -450,6 +450,12 @@ public class Config {
         @SerializedName("PRIVACY_POLICY_URL")
         private String privacyPolicyUrl;
 
+        @SerializedName("COOKIE_POLICY_URL")
+        private String cookiePolicyUrl;
+
+        @SerializedName("DATA_SELL_CONSENT_URL")
+        private String dataConsentUrl;
+
         @SerializedName("SUPPORTED_LANGUAGES")
         private ArrayList<String> supportedLanguages;
 
@@ -461,6 +467,10 @@ public class Config {
                     return eulaUrl;
                 case PRIVACY_POLICY:
                     return privacyPolicyUrl;
+                case COOKIE_POLICY:
+                    return cookiePolicyUrl;
+                case DATA_CONSENT:
+                    return dataConsentUrl;
                 default:
                     return null;
             }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/ConfigUtil.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/ConfigUtil.kt
@@ -100,7 +100,7 @@ class ConfigUtil {
             urlType: AgreementUrlType
         ): String? {
             if (config == null || TextUtils.isEmpty(config.getAgreementUrl(urlType))) {
-                return context.resources.getString(urlType.getStringResId())
+                return urlType.getStringResId()?.let { context.resources.getString(it) }
             }
             if (config.supportedLanguages != null && config.supportedLanguages.isNotEmpty()) {
                 val currentLocal = LocaleUtils.getCurrentDeviceLanguage(context)

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/AccountFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/AccountFragment.kt
@@ -26,6 +26,7 @@ import org.edx.mobile.event.MainDashboardRefreshEvent
 import org.edx.mobile.event.MediaStatusChangeEvent
 import org.edx.mobile.event.ProfilePhotoUpdatedEvent
 import org.edx.mobile.exception.ErrorMessage
+import org.edx.mobile.extenstion.isVisible
 import org.edx.mobile.extenstion.setVisibility
 import org.edx.mobile.http.HttpStatus
 import org.edx.mobile.model.iap.IAPFlowData
@@ -37,9 +38,11 @@ import org.edx.mobile.module.prefs.LoginPrefs
 import org.edx.mobile.module.prefs.PrefManager
 import org.edx.mobile.user.UserAPI.AccountDataUpdatedCallback
 import org.edx.mobile.user.UserService
+import org.edx.mobile.util.AgreementUrlType
 import org.edx.mobile.util.AppConstants
 import org.edx.mobile.util.BrowserUtil
 import org.edx.mobile.util.Config
+import org.edx.mobile.util.ConfigUtil
 import org.edx.mobile.util.FileUtil
 import org.edx.mobile.util.InAppPurchasesException
 import org.edx.mobile.util.NonNullObserver
@@ -120,6 +123,7 @@ class AccountFragment : BaseFragment() {
         updateWifiSwitch()
         updateSDCardSwitch()
         initHelpFields()
+        initPrivacyFields()
 
         val iapEnabled =
             environment.appFeaturesPrefs.isIAPEnabled(loginPrefs.isOddUserId)
@@ -376,6 +380,72 @@ class AccountFragment : BaseFragment() {
             environment.router.showUserProfile(requireActivity(), loginPrefs.username)
             setVideoQualityDescription(loginPrefs.videoQuality)
         }
+    }
+
+    private fun initPrivacyFields() {
+        ConfigUtil.getAgreementUrl(
+            this.requireContext(),
+            config.agreementUrlsConfig,
+            AgreementUrlType.PRIVACY_POLICY
+        )?.let { privacyPolicyUrl ->
+            binding.tvPrivacyPolicy.setVisibility(true)
+            binding.tvPrivacyPolicy.setOnClickListener {
+                environment.router.showAuthenticatedWebViewActivity(
+                    this.requireContext(),
+                    privacyPolicyUrl,
+                    getString(R.string.label_privacy_policy),
+                    false
+                )
+                trackEvent(
+                    Analytics.Events.PRIVACY_POLICY_CLICKED,
+                    Analytics.Values.PRIVACY_POLICY_CLICKED
+                )
+            }
+        }
+
+        ConfigUtil.getAgreementUrl(
+            this.requireContext(),
+            config.agreementUrlsConfig,
+            AgreementUrlType.COOKIE_POLICY
+        )?.let { cookiePolicyUrl ->
+            binding.tvCookiePolicy.setVisibility(true)
+            binding.tvCookiePolicy.setOnClickListener {
+                environment.router.showAuthenticatedWebViewActivity(
+                    this.requireContext(),
+                    cookiePolicyUrl,
+                    getString(R.string.label_cookie_policy),
+                    false
+                )
+                trackEvent(
+                    Analytics.Events.COOKIE_POLICY_CLICKED,
+                    Analytics.Values.COOKIE_POLICY_CLICKED
+                )
+            }
+        }
+
+        ConfigUtil.getAgreementUrl(
+            this.requireContext(),
+            config.agreementUrlsConfig,
+            AgreementUrlType.DATA_CONSENT
+        )?.let { dataConsentUrl ->
+            binding.tvDataConsentPolicy.setVisibility(true)
+            binding.tvDataConsentPolicy.setOnClickListener {
+                environment.router.showAuthenticatedWebViewActivity(
+                    this.requireContext(),
+                    dataConsentUrl,
+                    getString(R.string.label_do_not_sell_my_personal_data),
+                    false
+                )
+                trackEvent(
+                    Analytics.Events.DO_NOT_SELL_DATA_CLICKED,
+                    Analytics.Values.DO_NOT_SELL_DATA_CLICKED
+                )
+            }
+        }
+
+        val isContainerVisible = binding.tvPrivacyPolicy.isVisible()
+                || binding.tvCookiePolicy.isVisible() || binding.tvDataConsentPolicy.isVisible()
+        binding.containerPrivacy.setVisibility(isContainerVisible)
     }
 
     private fun updateWifiSwitch() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CertificateFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CertificateFragment.java
@@ -134,7 +134,7 @@ public class CertificateFragment extends BaseFragment {
         super.onActivityCreated(savedInstanceState);
 
         // Clear cookies before loading so that social sharing buttons are not displayed inside web view
-        EdxCookieManager.getSharedInstance(getContext()).clearWebViewCookie(false);
+        EdxCookieManager.getSharedInstance(getContext()).clearAndRetainCookie();
 
         webview.loadUrl(courseData.getCertificateURL());
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CertificateFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CertificateFragment.java
@@ -134,7 +134,7 @@ public class CertificateFragment extends BaseFragment {
         super.onActivityCreated(savedInstanceState);
 
         // Clear cookies before loading so that social sharing buttons are not displayed inside web view
-        EdxCookieManager.getSharedInstance(getContext()).clearAndRetainCookie();
+        EdxCookieManager.getSharedInstance(getContext()).clearAndRetainCookies();
 
         webview.loadUrl(courseData.getCertificateURL());
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CertificateFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CertificateFragment.java
@@ -134,7 +134,7 @@ public class CertificateFragment extends BaseFragment {
         super.onActivityCreated(savedInstanceState);
 
         // Clear cookies before loading so that social sharing buttons are not displayed inside web view
-        EdxCookieManager.getSharedInstance(getContext()).clearWebWiewCookie();
+        EdxCookieManager.getSharedInstance(getContext()).clearWebViewCookie(false);
 
         webview.loadUrl(courseData.getCertificateURL());
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/AuthenticatedWebView.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/AuthenticatedWebView.java
@@ -197,6 +197,7 @@ public class AuthenticatedWebView extends FrameLayout implements RefreshListener
                 } else {
                     hideLoadingProgress();
                 }
+                EdxCookieManager.getSharedInstance(getContext()).retainSessionCookies();
                 super.onPageFinished(view, url);
             }
         };


### PR DESCRIPTION
### Description

[LEARNER-9200](https://2u-internal.atlassian.net/browse/LEARNER-9200)

Added a new privacy section in the user profile screen above the help section. Tapping on each option in the privacy section opens a webview for the corresponding option.

### Config 
https://github.com/edx/edx-mobile-config/pull/137