### PR TITLE
fix: NPE on Posts in Discussion tab

### DIFF
--- a/OpenEdXMobile/res/layout/fragment_add_response_or_comment.xml
+++ b/OpenEdXMobile/res/layout/fragment_add_response_or_comment.xml
@@ -40,7 +40,7 @@
                     android:id="@+id/discussion_render_body"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    app:bodyStyle="@style/discussion_regular_text" />
+                    app:bodyTextAppearance="@style/discussion_regular_text" />
 
             </LinearLayout>
 

--- a/OpenEdXMobile/res/layout/fragment_add_response_or_comment.xml
+++ b/OpenEdXMobile/res/layout/fragment_add_response_or_comment.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <ScrollView
@@ -37,7 +38,9 @@
 
                 <org.edx.mobile.view.custom.EdxDiscussionBody
                     android:id="@+id/discussion_render_body"
-                    style="@style/discussion_regular_text" />
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:bodyStyle="@style/discussion_regular_text" />
 
             </LinearLayout>
 

--- a/OpenEdXMobile/res/layout/row_discussion_comments_comment.xml
+++ b/OpenEdXMobile/res/layout/row_discussion_comments_comment.xml
@@ -22,7 +22,9 @@
 
         <org.edx.mobile.view.custom.EdxDiscussionBody
             android:id="@+id/discussion_render_body"
-            style="@style/discussion_regular_text" />
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:bodyStyle="@style/discussion_regular_text" />
 
         <!-- This container layout is only defined to add bottom padding to the parent view, when
              the enclosed TextView's visibility is set to GONE. -->

--- a/OpenEdXMobile/res/layout/row_discussion_comments_comment.xml
+++ b/OpenEdXMobile/res/layout/row_discussion_comments_comment.xml
@@ -24,7 +24,7 @@
             android:id="@+id/discussion_render_body"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:bodyStyle="@style/discussion_regular_text" />
+            app:bodyTextAppearance="@style/discussion_regular_text" />
 
         <!-- This container layout is only defined to add bottom padding to the parent view, when
              the enclosed TextView's visibility is set to GONE. -->

--- a/OpenEdXMobile/res/layout/row_discussion_comments_response.xml
+++ b/OpenEdXMobile/res/layout/row_discussion_comments_response.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/edX.Widget.CardView"
     android:layout_width="match_parent"
@@ -20,7 +21,9 @@
 
         <org.edx.mobile.view.custom.EdxDiscussionBody
             android:id="@+id/discussion_render_body"
-            style="@style/discussion_regular_text" />
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:bodyStyle="@style/discussion_regular_text" />
 
         <TextView
             android:id="@+id/discussion_comment_count_report_text_view"

--- a/OpenEdXMobile/res/layout/row_discussion_comments_response.xml
+++ b/OpenEdXMobile/res/layout/row_discussion_comments_response.xml
@@ -23,7 +23,7 @@
             android:id="@+id/discussion_render_body"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:bodyStyle="@style/discussion_regular_text" />
+            app:bodyTextAppearance="@style/discussion_regular_text" />
 
         <TextView
             android:id="@+id/discussion_comment_count_report_text_view"

--- a/OpenEdXMobile/res/layout/row_discussion_responses_response.xml
+++ b/OpenEdXMobile/res/layout/row_discussion_responses_response.xml
@@ -29,7 +29,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="5dp"
-                app:bodyStyle="@style/discussion_regular_text" />
+                app:bodyTextAppearance="@style/discussion_regular_text" />
 
             <TextView
                 android:id="@+id/discussion_responses_answer_author_text_view"

--- a/OpenEdXMobile/res/layout/row_discussion_responses_response.xml
+++ b/OpenEdXMobile/res/layout/row_discussion_responses_response.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/edX.Widget.CardView"
     android:layout_width="match_parent"
@@ -25,8 +26,10 @@
 
             <org.edx.mobile.view.custom.EdxDiscussionBody
                 android:id="@+id/discussion_render_body"
-                style="@style/discussion_regular_text"
-                android:layout_marginBottom="5dp" />
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="5dp"
+                app:bodyStyle="@style/discussion_regular_text" />
 
             <TextView
                 android:id="@+id/discussion_responses_answer_author_text_view"

--- a/OpenEdXMobile/res/layout/row_discussion_responses_thread.xml
+++ b/OpenEdXMobile/res/layout/row_discussion_responses_thread.xml
@@ -47,7 +47,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/discussion_responses_standard_margin"
-            app:bodyStyle="@style/discussion_regular_text" />
+            app:bodyTextAppearance="@style/discussion_regular_text" />
 
         <TextView
             android:id="@+id/discussion_responses_thread_row_visibility_text_view"

--- a/OpenEdXMobile/res/layout/row_discussion_responses_thread.xml
+++ b/OpenEdXMobile/res/layout/row_discussion_responses_thread.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -43,8 +44,10 @@
 
         <org.edx.mobile.view.custom.EdxDiscussionBody
             android:id="@+id/discussion_render_body"
-            style="@style/discussion_regular_text"
-            android:layout_marginBottom="@dimen/discussion_responses_standard_margin" />
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/discussion_responses_standard_margin"
+            app:bodyStyle="@style/discussion_regular_text" />
 
         <TextView
             android:id="@+id/discussion_responses_thread_row_visibility_text_view"

--- a/OpenEdXMobile/res/values/attrs.xml
+++ b/OpenEdXMobile/res/values/attrs.xml
@@ -24,7 +24,7 @@
     </declare-styleable>
 
     <declare-styleable name="EdxDiscussionBody">
-        <attr name="bodyStyle" format="reference" />
+        <attr name="bodyTextAppearance" format="reference" />
     </declare-styleable>
 
     <!--  Font attributes for the app  -->

--- a/OpenEdXMobile/res/values/attrs.xml
+++ b/OpenEdXMobile/res/values/attrs.xml
@@ -23,6 +23,10 @@
         <attr name="contourSize" format="dimension"/>
     </declare-styleable>
 
+    <declare-styleable name="EdxDiscussionBody">
+        <attr name="bodyStyle" format="reference" />
+    </declare-styleable>
+
     <!--  Font attributes for the app  -->
     <attr name="fontItalic" format="reference" />
     <attr name="fontRegular" format="reference" />

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/EdxDiscussionBody.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/EdxDiscussionBody.kt
@@ -5,6 +5,7 @@ import android.util.AttributeSet
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.FrameLayout
 import android.widget.TextView
+import androidx.core.widget.TextViewCompat
 import org.edx.mobile.R
 import org.edx.mobile.extenstion.renderHtml
 import java.util.regex.Pattern
@@ -15,15 +16,15 @@ class EdxDiscussionBody @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr) {
 
-    private val bodyStyle: Int
+    private val bodyTextAppearance: Int
 
     init {
         context.theme.obtainStyledAttributes(
             attrs, R.styleable.EdxDiscussionBody, 0, 0
         ).apply {
             try {
-                bodyStyle = getResourceId(
-                    R.styleable.EdxDiscussionBody_bodyStyle, 0
+                bodyTextAppearance = getResourceId(
+                    R.styleable.EdxDiscussionBody_bodyTextAppearance, 0
                 )
             } finally {
                 recycle()
@@ -40,7 +41,7 @@ class EdxDiscussionBody @JvmOverloads constructor(
             this.removeAllViews()
             if (isPlainHtml(body)) {
                 this.addView(TextView(context).also {
-                    it.setTextAppearance(bodyStyle)
+                    TextViewCompat.setTextAppearance(it, bodyTextAppearance)
                     it.renderHtml(body)
                 })
             } else {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/EdxDiscussionBody.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/EdxDiscussionBody.kt
@@ -15,6 +15,22 @@ class EdxDiscussionBody @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr) {
 
+    private val bodyStyle: Int
+
+    init {
+        context.theme.obtainStyledAttributes(
+            attrs, R.styleable.EdxDiscussionBody, 0, 0
+        ).apply {
+            try {
+                bodyStyle = getResourceId(
+                    R.styleable.EdxDiscussionBody_bodyStyle, 0
+                )
+            } finally {
+                recycle()
+            }
+        }
+    }
+
     /**
      * Method to render the [body] based on HTML paragraph tag
      * @param body  rendered body of the discussion
@@ -22,7 +38,8 @@ class EdxDiscussionBody @JvmOverloads constructor(
     fun setBody(body: String?) {
         body?.let {
             if (isPlainHtml(body)) {
-                this.addView(TextView(context, null, 0, R.style.discussion_regular_text).also {
+                this.addView(TextView(context).also {
+                    it.setTextAppearance(bodyStyle)
                     it.renderHtml(body)
                 })
             } else {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/EdxDiscussionBody.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/EdxDiscussionBody.kt
@@ -2,15 +2,17 @@ package org.edx.mobile.view.custom
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.FrameLayout
 import android.widget.TextView
+import org.edx.mobile.R
 import org.edx.mobile.extenstion.renderHtml
 import java.util.regex.Pattern
 
 class EdxDiscussionBody @JvmOverloads constructor(
     context: Context,
-    private val attrs: AttributeSet? = null,
-    private val defStyleAttr: Int = 0
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr) {
 
     /**
@@ -20,11 +22,12 @@ class EdxDiscussionBody @JvmOverloads constructor(
     fun setBody(body: String?) {
         body?.let {
             if (isPlainHtml(body)) {
-                this.addView(TextView(context, attrs, defStyleAttr).also {
+                this.addView(TextView(context, null, 0, R.style.discussion_regular_text).also {
                     it.renderHtml(body)
                 })
             } else {
-                this.addView(EdxWebView(context, attrs).also {
+                this.addView(EdxWebView(context, null).also {
+                    it.layoutParams = LayoutParams(WRAP_CONTENT, WRAP_CONTENT)
                     it.loadDataWithBaseURL(null, body, "text/html", "utf-8", null)
                 })
             }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/EdxDiscussionBody.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/EdxDiscussionBody.kt
@@ -37,6 +37,7 @@ class EdxDiscussionBody @JvmOverloads constructor(
      */
     fun setBody(body: String?) {
         body?.let {
+            this.removeAllViews()
             if (isPlainHtml(body)) {
                 this.addView(TextView(context).also {
                     it.setTextAppearance(bodyStyle)


### PR DESCRIPTION
### Description

[LEARNER-9224](https://2u-internal.atlassian.net/browse/LEARNER-9224)

The AttributeSet of the EdxDiscussionBody was not applicable for the internal views and was causing a NullPointerException (NPE) on some devices.

### Notes
- The app was crashing on Xiaomi and Huawei devices only
- [Crash](https://console.firebase.google.com/u/1/project/openedx-mobile/crashlytics/app/android:org.edx.mobile/issues/17b84746eb1dd5cb346fab1b53d28d92?time=last-seven-days&types=crash&versions=3.2.7%20(3002007)&sessionEventKey=63DA9D6E024500017793F8833B7148C0_1773682186230934946) report on Crashlytics 

### Testing
- [ ] Test on any Android S+ device
- [ ] Test on Xiaomi, Huawei (if possible) and one other device 
