### PR TITLE
fix: Sync Loader Detached from Fragment

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/DateUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/DateUtil.java
@@ -32,7 +32,6 @@ public class DateUtil {
         final ParsePosition parsePosition = new ParsePosition(0);
         try {
             parsedate = ISO8601Utils.parse(date, parsePosition);
-            logger.debug("Parsed Data" + parsedate);
             return parsedate;
 
         } catch (ParseException e) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDatesPageFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDatesPageFragment.kt
@@ -35,6 +35,7 @@ import org.edx.mobile.util.CourseDateUtil
 import org.edx.mobile.util.PermissionsUtil
 import org.edx.mobile.util.ResourceUtil
 import org.edx.mobile.util.UiUtils
+import org.edx.mobile.util.observer.EventObserver
 import org.edx.mobile.view.adapters.CourseDatesAdapter
 import org.edx.mobile.view.dialog.AlertDialogFragment
 import org.edx.mobile.viewModel.CourseDateViewModel
@@ -172,7 +173,7 @@ class CourseDatesPageFragment : OfflineSupportBaseFragment(), BaseFragment.Permi
             initDatesBanner(it)
         })
 
-        viewModel.syncLoader.observe(viewLifecycleOwner, Observer { syncLoader ->
+        viewModel.syncLoader.observe(viewLifecycleOwner, EventObserver { syncLoader ->
             if (syncLoader) {
                 loaderDialog.isCancelable = false
                 loaderDialog.showNow(childFragmentManager, null)
@@ -537,7 +538,6 @@ class CourseDatesPageFragment : OfflineSupportBaseFragment(), BaseFragment.Permi
                 }).show(childFragmentManager, null)
         }
     }
-
 
     private fun showAddCalendarSuccessSnackbar() {
         val snackbarErrorNotification = SnackbarErrorNotification(binding.root)

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDatesPageFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDatesPageFragment.kt
@@ -183,7 +183,7 @@ class CourseDatesPageFragment : OfflineSupportBaseFragment(), BaseFragment.Permi
             }
         })
 
-        viewModel.courseDates.observe(viewLifecycleOwner, Observer { dates ->
+        viewModel.courseDates.observe(viewLifecycleOwner, EventObserver { dates ->
             if (dates.courseDateBlocks.isNullOrEmpty()) {
                 viewModel.setError(
                     ErrorMessage.COURSE_DATES_CODE,

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -481,6 +481,8 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
             @Override
             protected void onFailure(@NonNull Throwable error) {
                 super.onFailure(error);
+                if (!isAdded()) return;
+
                 FullscreenLoaderDialogFragment fullscreenLoader = FullscreenLoaderDialogFragment
                         .getRetainedInstance(getChildFragmentManager());
                 if (error instanceof CourseContentNotValidException) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -237,7 +237,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
     private void initCourseDateObserver() {
         courseDateViewModel = new ViewModelProvider(this).get(CourseDateViewModel.class);
 
-        courseDateViewModel.getSyncLoader().observe(getViewLifecycleOwner(), showLoader -> {
+        courseDateViewModel.getSyncLoader().observe(getViewLifecycleOwner(), new EventObserver<>(showLoader -> {
             if (showLoader) {
                 loaderDialog.setCancelable(false);
                 loaderDialog.showNow(getChildFragmentManager(), null);
@@ -246,7 +246,8 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
                 showCalendarUpdatedSnackbar();
                 trackCalendarEvent(Analytics.Events.CALENDAR_UPDATE_SUCCESS, Analytics.Values.CALENDAR_UPDATE_SUCCESS);
             }
-        });
+            return null;
+        }));
 
         courseDateViewModel.getCourseDates().observe(getViewLifecycleOwner(), courseDates -> {
             if (courseDates.getCourseDateBlocks() != null) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -249,7 +249,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
             return null;
         }));
 
-        courseDateViewModel.getCourseDates().observe(getViewLifecycleOwner(), courseDates -> {
+        courseDateViewModel.getCourseDates().observe(getViewLifecycleOwner(), new EventObserver<>(courseDates -> {
             if (courseDates.getCourseDateBlocks() != null) {
                 courseDates.organiseCourseDates();
                 long outdatedCalenderId = CalendarUtils.isCalendarOutOfDate(
@@ -258,7 +258,8 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
                     showCalendarOutOfDateDialog(outdatedCalenderId);
                 }
             }
-        });
+            return null;
+        }));
 
         courseDateViewModel.getBannerInfo().observe(getViewLifecycleOwner(), this::initDatesBanner);
 
@@ -481,7 +482,9 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
             @Override
             protected void onFailure(@NonNull Throwable error) {
                 super.onFailure(error);
-                if (!isAdded()) return;
+                if (!isAdded()) {
+                    return;
+                }
 
                 FullscreenLoaderDialogFragment fullscreenLoader = FullscreenLoaderDialogFragment
                         .getRetainedInstance(getChildFragmentManager());

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitWebViewFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitWebViewFragment.java
@@ -42,6 +42,7 @@ import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.CalendarUtils;
 import org.edx.mobile.util.ConfigUtil;
 import org.edx.mobile.util.CourseDateUtil;
+import org.edx.mobile.util.observer.EventObserver;
 import org.edx.mobile.view.custom.PreLoadingListener;
 import org.edx.mobile.view.custom.URLInterceptorWebViewClient;
 import org.edx.mobile.view.dialog.AlertDialogFragment;
@@ -260,7 +261,7 @@ public class CourseUnitWebViewFragment extends CourseUnitFragment {
     private void initObserver() {
         courseDateViewModel = new ViewModelProvider(this).get(CourseDateViewModel.class);
 
-        courseDateViewModel.getSyncLoader().observe(getViewLifecycleOwner(), showLoader -> {
+        courseDateViewModel.getSyncLoader().observe(getViewLifecycleOwner(), new EventObserver<>(showLoader -> {
             if (showLoader) {
                 loaderDialog.setCancelable(false);
                 loaderDialog.showNow(getChildFragmentManager(), null);
@@ -269,7 +270,8 @@ public class CourseUnitWebViewFragment extends CourseUnitFragment {
                 showCalendarUpdatedSnackbar();
                 trackCalendarEvent(Analytics.Events.CALENDAR_UPDATE_SUCCESS, Analytics.Values.CALENDAR_UPDATE_SUCCESS);
             }
-        });
+            return null;
+        }));
 
         courseDateViewModel.getCourseDates().observe(getViewLifecycleOwner(), courseDates -> {
             if (courseDates.getCourseDateBlocks() != null) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitWebViewFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitWebViewFragment.java
@@ -273,7 +273,7 @@ public class CourseUnitWebViewFragment extends CourseUnitFragment {
             return null;
         }));
 
-        courseDateViewModel.getCourseDates().observe(getViewLifecycleOwner(), courseDates -> {
+        courseDateViewModel.getCourseDates().observe(getViewLifecycleOwner(), new EventObserver<>(courseDates -> {
             if (courseDates.getCourseDateBlocks() != null) {
                 courseDates.organiseCourseDates();
                 long outdatedCalenderId = CalendarUtils.isCalendarOutOfDate(
@@ -282,7 +282,8 @@ public class CourseUnitWebViewFragment extends CourseUnitFragment {
                     showCalendarOutOfDateDialog(outdatedCalenderId);
                 }
             }
-        });
+            return null;
+        }));
 
         courseDateViewModel.getBannerInfo().observe(getViewLifecycleOwner(), this::initInfoBanner);
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/CourseDateViewModel.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/CourseDateViewModel.kt
@@ -18,6 +18,8 @@ import org.edx.mobile.model.course.CourseDates
 import org.edx.mobile.model.course.ResetCourseDates
 import org.edx.mobile.repository.CourseDatesRepository
 import org.edx.mobile.util.CalendarUtils
+import org.edx.mobile.util.observer.Event
+import org.edx.mobile.util.observer.postEvent
 import java.util.Calendar
 import javax.inject.Inject
 
@@ -26,8 +28,8 @@ class CourseDateViewModel @Inject constructor(
     private val repository: CourseDatesRepository
 ) : ViewModel() {
 
-    private val _syncLoader = MutableLiveData<Boolean>()
-    val syncLoader: LiveData<Boolean>
+    private val _syncLoader = MutableLiveData<Event<Boolean>>()
+    val syncLoader: LiveData<Event<Boolean>>
         get() = _syncLoader
 
     private val _showLoader = MutableLiveData<Boolean>()
@@ -73,7 +75,7 @@ class CourseDateViewModel @Inject constructor(
         resetSyncingCalendarTime()
         val syncingCalendarStartTime: Long = Calendar.getInstance().timeInMillis
         areEventsUpdated = updatedEvent
-        _syncLoader.value = true
+        _syncLoader.postEvent(true)
 
         viewModelScope.launch(Dispatchers.IO) {
             courseDates.value?.let { courseDates ->
@@ -96,7 +98,7 @@ class CourseDateViewModel @Inject constructor(
                     SystemClock.sleep(1000 - syncingCalendarTime)
                 }
             } ?: run { syncingCalendarTime = 0 }
-            _syncLoader.postValue(false)
+            _syncLoader.postEvent(false)
         }
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/CourseDateViewModel.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/CourseDateViewModel.kt
@@ -40,8 +40,8 @@ class CourseDateViewModel @Inject constructor(
     val swipeRefresh: LiveData<Boolean>
         get() = _swipeRefresh
 
-    private val _courseDates = MutableLiveData<CourseDates>()
-    val courseDates: LiveData<CourseDates>
+    private val _courseDates = MutableLiveData<Event<CourseDates>>()
+    val courseDates: LiveData<Event<CourseDates>>
         get() = _courseDates
 
     private val _bannerInfo = MutableLiveData<CourseBannerInfoModel?>()
@@ -78,7 +78,7 @@ class CourseDateViewModel @Inject constructor(
         _syncLoader.postEvent(true)
 
         viewModelScope.launch(Dispatchers.IO) {
-            courseDates.value?.let { courseDates ->
+            courseDates.value?.peekContent()?.let { courseDates ->
                 courseDates.courseDateBlocks?.forEach { courseDateBlock ->
                     CalendarUtils.addEventsIntoCalendar(
                         context = context,
@@ -118,7 +118,7 @@ class CourseDateViewModel @Inject constructor(
                 override fun onSuccess(result: Result.Success<CourseDates>) {
                     if (result.isSuccessful && result.data != null) {
                         result.data.let {
-                            _courseDates.postValue(it)
+                            _courseDates.postEvent(it)
                         }
                         fetchCourseDatesBannerInfo(courseId, true)
                     } else {


### PR DESCRIPTION
### Description

[LEARNER-9169](https://2u-internal.atlassian.net/browse/LEARNER-9169)

The syncLoader observer reinitialized on orientation change and fetched the last store value that was false. The false value triggered the Sync Loader dismiss flow that tried to dismiss the already detached dialog and caused the issue.
