### PR TITLE
chore: Remove the Upgrade Banner from the Course Home page

### DIFF
--- a/OpenEdXMobile/res/layout/layout_course_dates_banner.xml
+++ b/OpenEdXMobile/res/layout/layout_course_dates_banner.xml
@@ -46,9 +46,9 @@
                 android:layout_height="wrap_content"
                 android:fontFamily="?attr/fontRegular"
                 android:lineSpacingMultiplier="@dimen/course_date_desc_line_spacing"
-                android:text="@string/course_dates_info_banner"
                 android:textColor="@color/neutralXDark"
-                android:textSize="@dimen/edx_x_small" />
+                android:textSize="@dimen/edx_x_small"
+                tools:text="@string/course_dates_info_banner" />
         </LinearLayout>
 
         <!--  Use legacy text field instated of material-components-->

--- a/OpenEdXMobile/res/layout/layout_upgrade_btn.xml
+++ b/OpenEdXMobile/res/layout/layout_upgrade_btn.xml
@@ -28,7 +28,7 @@
                 app:icon="@drawable/ic_lock"
                 app:iconGravity="textStart"
                 app:iconTint="@color/edx_brand_button_text"
-                tools:text="@string/course_dates_banner_upgrade_to_graded_button" />
+                tools:text="@string/label_upgrade_course_button" />
 
             <com.google.android.material.progressindicator.CircularProgressIndicator
                 android:id="@+id/loading_indicator"

--- a/OpenEdXMobile/res/values-ar/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values-ar/course_banners_strings.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Message Course Dashboard Info Banner -->
-    <string name="course_dashboard_info_banner"><b>لقد وضعنا لك، على سبيل الاقتراح، جدولاً ليساعدك على متابعة التقدم في المسار الصحيح.</b>
-        ولا داعي للقلق؛ فهو جدول يتسم بالمرونة بما يُمكِّنك من التعلم على طريقتك الخاصة. فإذا حدث أن تأخرت عن المواعيد المقترحة في هذا الجدول،
-        فباستطاعتك تعديلها لتتابع التقدم في مسارك الصحيح.</string>
-    <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
-    <string name="course_dates_banner_upgrade_to_graded_button">ترفيع المستوى الآن</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date">يبدو انك فاتتك بعض المراعيد المهمة بناء على جدولنا المقترح
 لتبقى نفسك على المسار الصحيح، يمكنك ترقية جدولك و نقل واجبات الماضي الي المستقبل. لا تقلق لن تخسر اي تقدم فعلته عندما تنقل التواريخ المحددة</string>

--- a/OpenEdXMobile/res/values-ar/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values-ar/course_banners_strings.xml
@@ -4,14 +4,8 @@
     <string name="course_dashboard_info_banner"><b>لقد وضعنا لك، على سبيل الاقتراح، جدولاً ليساعدك على متابعة التقدم في المسار الصحيح.</b>
         ولا داعي للقلق؛ فهو جدول يتسم بالمرونة بما يُمكِّنك من التعلم على طريقتك الخاصة. فإذا حدث أن تأخرت عن المواعيد المقترحة في هذا الجدول،
         فباستطاعتك تعديلها لتتابع التقدم في مسارك الصحيح.</string>
-    <!-- Message Course Dashboard Banner Upgrade to Complete Graded -->
-    <string name="course_dashboard_banner_upgrade_to_graded">أنت تقوم بمراجعة هذه الدورة التدريبية 1
-مما يعني أنك غير قادر على المشاركة في الواجبات المقدرة. لإكمال الواجبات المقدرة كجزء من هذه الدورة التدريبية ، يمكنك الترقية اليوم.</string>
     <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
     <string name="course_dates_banner_upgrade_to_graded_button">ترفيع المستوى الآن</string>
-    <!-- Message Course Dashboard Banner Upgrade to Reset -->
-    <string name="course_dashboard_banner_upgrade_to_reset">انت تقوم بمراجعة هذه الدورة التدريبية
-مما يعني انك غير قادر ان تشارك في الواجبات المقدرة. يبدو انك فاتتك بعض المواعيد المهمة بناء على جدولنا .لتكمل الواجبات المقدرة كجزء من هذه الدورة ونقل واجبات الماضي الي المستقبل، يمكنك الترقية اليوم</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date">يبدو انك فاتتك بعض المراعيد المهمة بناء على جدولنا المقترح
 لتبقى نفسك على المسار الصحيح، يمكنك ترقية جدولك و نقل واجبات الماضي الي المستقبل. لا تقلق لن تخسر اي تقدم فعلته عندما تنقل التواريخ المحددة</string>

--- a/OpenEdXMobile/res/values-de-rDE/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values-de-rDE/course_banners_strings.xml
@@ -4,14 +4,8 @@
     <string name="course_dashboard_info_banner"><b>Wir haben einen vorgeschlagenen Zeitplan erstellt, um Ihnen zu helfen, Ihre Planung einzuhalten.</b>
 Aber keine Sorge – er ist flexibel, sodass Sie in Ihrem eigenen Tempo lernen können. Sollten Sie mit unseren Terminvorschlägen in Verzug geraten,
 können sie Sie anpassen, um Ihren Zeitplan einzuhalten.</string>
-    <!-- Message Course Dashboard Banner Upgrade to Complete Graded -->
-    <string name="course_dashboard_banner_upgrade_to_graded"><b>Sie sind Gasthörer für diesen Kurs,</b>
-was bedeutet, dass Sie nicht an benoteten Aufgaben teilnehmen können. Um benotete Aufgaben im Rahmen dieses Kurses abzuschließen, können Sie noch heute ein Upgrade durchführen.</string>
     <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
     <string name="course_dates_banner_upgrade_to_graded_button">Jetzt Upgrade durchführen</string>
-    <!-- Message Course Dashboard Banner Upgrade to Reset -->
-    <string name="course_dashboard_banner_upgrade_to_reset"><b>Sie sind Gasthörer für diesen Kurs,</b>
-was bedeutet, dass Sie nicht an benoteten Aufgaben teilnehmen können. Es sieht so aus, als ob Sie einige wichtige Fristen verpasst haben, basierend auf unserem vorgeschlagenen Zeitplan. Um benotete Aufgaben im Rahmen dieses Kurses abzuschließen und überfällige Aufgaben in die Zukunft zu verschieben, können Sie noch heute ein Upgrade durchführen.</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date"><b>Es sieht so aus, als ob Sie einige wichtige, auf unserem vorgeschlagenen Zeitplan basierende Fristen verpasst haben.</b>
 Um den Zeitplan einzuhalten, können Sie ihn aktualisieren und die überfälligen Aufgaben in die Zukunft verschieben. Keine Sorge – Sie verlieren keinen Ihrer Fortschritte, wenn Sie Ihre Fälligkeitstermine verschieben.</string>

--- a/OpenEdXMobile/res/values-de-rDE/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values-de-rDE/course_banners_strings.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Message Course Dashboard Info Banner -->
-    <string name="course_dashboard_info_banner"><b>Wir haben einen vorgeschlagenen Zeitplan erstellt, um Ihnen zu helfen, Ihre Planung einzuhalten.</b>
-Aber keine Sorge – er ist flexibel, sodass Sie in Ihrem eigenen Tempo lernen können. Sollten Sie mit unseren Terminvorschlägen in Verzug geraten,
-können sie Sie anpassen, um Ihren Zeitplan einzuhalten.</string>
-    <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
-    <string name="course_dates_banner_upgrade_to_graded_button">Jetzt Upgrade durchführen</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date"><b>Es sieht so aus, als ob Sie einige wichtige, auf unserem vorgeschlagenen Zeitplan basierende Fristen verpasst haben.</b>
 Um den Zeitplan einzuhalten, können Sie ihn aktualisieren und die überfälligen Aufgaben in die Zukunft verschieben. Keine Sorge – Sie verlieren keinen Ihrer Fortschritte, wenn Sie Ihre Fälligkeitstermine verschieben.</string>

--- a/OpenEdXMobile/res/values-es/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values-es/course_banners_strings.xml
@@ -4,14 +4,8 @@
     <string name="course_dashboard_info_banner"><b>Hemos creado un cronograma sugerido para ayudarte a mantenerte encaminado en el curso.</b>
         Pero no te preocupes, es flexible para que puedas aprender a tu propio ritmo. Si te atrasas en las fechas sugeridas,
         podrás ajustarlas para mantenerte encaminado.</string>
-    <!-- Message Course Dashboard Banner Upgrade to Complete Graded -->
-    <string name="course_dashboard_banner_upgrade_to_graded"><b>Estás en la opción gratuita del curso,</b>
-        lo que significa que no podrás participar en las tareas calificadas. Para completar las tareas calificadas como parte de este curso, puedes cambiar a la opción paga.</string>
     <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
     <string name="course_dates_banner_upgrade_to_graded_button">Acutalizar ahora</string>
-    <!-- Message Course Dashboard Banner Upgrade to Reset -->
-    <string name="course_dashboard_banner_upgrade_to_reset"><b>Estás en la opción gratuita del curso,</b>
-        lo que significa que no puedes participar en tareas calificadas. Parece que no cumpliste con algunos plazos importantes según nuestro calendario sugerido. Para completar las asignaciones calificadas como parte de este curso y cambiar las asignaciones vencidas al futuro, puedes cambiarte a la opción paga.</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date"><b>Parece que no has cumplido con algunos plazos importantes según nuestro calendario sugerido.</b>
         Para mantenerte en el camino adecuado, puedes actualizar este calendario y mover las tareas vencidas hacia el futuro. No te preocupes, no perderás nada de lo que hayas avanzado cuando cambies las fechas de entrega.</string>

--- a/OpenEdXMobile/res/values-es/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values-es/course_banners_strings.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Message Course Dashboard Info Banner -->
-    <string name="course_dashboard_info_banner"><b>Hemos creado un cronograma sugerido para ayudarte a mantenerte encaminado en el curso.</b>
-        Pero no te preocupes, es flexible para que puedas aprender a tu propio ritmo. Si te atrasas en las fechas sugeridas,
-        podrás ajustarlas para mantenerte encaminado.</string>
-    <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
-    <string name="course_dates_banner_upgrade_to_graded_button">Acutalizar ahora</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date"><b>Parece que no has cumplido con algunos plazos importantes según nuestro calendario sugerido.</b>
         Para mantenerte en el camino adecuado, puedes actualizar este calendario y mover las tareas vencidas hacia el futuro. No te preocupes, no perderás nada de lo que hayas avanzado cuando cambies las fechas de entrega.</string>

--- a/OpenEdXMobile/res/values-fr/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values-fr/course_banners_strings.xml
@@ -4,14 +4,8 @@
     <string name="course_dashboard_info_banner"><b>Nous vous suggérons un programme prédéfini pour vous aider à rester sur la bonne voie.</b>
         Mais ne vous inquiétez pas : il est flexible et vous pouvez donc apprendre à votre rythme. Si vous prenez du retard par rapport aux dates suggérées,
         vous pouvez les ajuster afin de rester sur la bonne voie.</string>
-    <!-- Message Course Dashboard Banner Upgrade to Complete Graded -->
-    <string name="course_dashboard_banner_upgrade_to_graded"><b>Vous suivez ce cours en tant qu\'auditeur libre,</b>
-        ce qui signifie que vous ne pouvez pas participer aux devoirs notés. Pour faire les devoirs notés dans le cadre de ce cours, vous pouvez mettre à niveau votre inscription dès aujourd\'hui.</string>
     <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
     <string name="course_dates_banner_upgrade_to_graded_button">Mettre à jour maintenant</string>
-    <!-- Message Course Dashboard Banner Upgrade to Reset -->
-    <string name="course_dashboard_banner_upgrade_to_reset"><b>Vous suivez ce cours en tant qu\'auditeur libre,</b>
-        ce qui signifie que vous ne pouvez pas participer aux devoirs notés. Il semblerait que vous ayez manqué des échéances importantes de notre programme suggéré. Pour faire les devoirs notés dans le cadre de ce cours et pouvoir rendre les devoirs passés un peu plus tard, vous pouvez mettre à niveau votre inscription dès aujourd\'hui.</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date"><b>Il semblerait que vous ayez manqué des échéances importantes de notre programme suggéré.</b>
         Pour rester sur la bonne voie, vous pouvez mettre à jour ce programme et rendre les devoirs passés un peu plus tard. Ne vous inquiétez pas : en modifiant les échéances, vous ne perdrez pas les progrès que vous avez faits.</string>

--- a/OpenEdXMobile/res/values-fr/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values-fr/course_banners_strings.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Message Course Dashboard Info Banner -->
-    <string name="course_dashboard_info_banner"><b>Nous vous suggérons un programme prédéfini pour vous aider à rester sur la bonne voie.</b>
-        Mais ne vous inquiétez pas : il est flexible et vous pouvez donc apprendre à votre rythme. Si vous prenez du retard par rapport aux dates suggérées,
-        vous pouvez les ajuster afin de rester sur la bonne voie.</string>
-    <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
-    <string name="course_dates_banner_upgrade_to_graded_button">Mettre à jour maintenant</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date"><b>Il semblerait que vous ayez manqué des échéances importantes de notre programme suggéré.</b>
         Pour rester sur la bonne voie, vous pouvez mettre à jour ce programme et rendre les devoirs passés un peu plus tard. Ne vous inquiétez pas : en modifiant les échéances, vous ne perdrez pas les progrès que vous avez faits.</string>

--- a/OpenEdXMobile/res/values-iw/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values-iw/course_banners_strings.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Message Course Dashboard Info Banner -->
-    <string name="course_dashboard_info_banner"><b>בנינו לוח זמנים מוצע כדי לעזור לך להישאר על המסלול.</b>
-       אבל אל דאגה - זה עדיין גמיש כך שתוכל ללמוד בקצב שלך. אם במקרה תיקלע לפיגור בתאריכים המוצעים שלנו,
-תוכל להתאים אותם כדי לשמור על עצמך על המסלול. </string>
-    <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
-    <string name="course_dates_banner_upgrade_to_graded_button">שדרג עכשיו</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date"><b>נראה שהחמצת כמה מועדים חשובים בהתבסס על לוח הזמנים המוצע שלנו.</b>
         כדי לשמור על עצמכם על המסלול, תוכלו לעדכן את לוח הזמנים הזה ולהעביר את ההקצאות שהוגשו לעתיד. אל דאגה - לא תאבד שום התקדמות שהשגת כאשר תשנה את תאריכי היעד שלך.</string>

--- a/OpenEdXMobile/res/values-iw/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values-iw/course_banners_strings.xml
@@ -4,14 +4,8 @@
     <string name="course_dashboard_info_banner"><b>בנינו לוח זמנים מוצע כדי לעזור לך להישאר על המסלול.</b>
        אבל אל דאגה - זה עדיין גמיש כך שתוכל ללמוד בקצב שלך. אם במקרה תיקלע לפיגור בתאריכים המוצעים שלנו,
 תוכל להתאים אותם כדי לשמור על עצמך על המסלול. </string>
-    <!-- Message Course Dashboard Banner Upgrade to Complete Graded -->
-    <string name="course_dashboard_banner_upgrade_to_graded"><b>אתה מבקר את הקורס הזה,</b>
-        מה שאומר שאינך יכול להשתתף במטלות מדורגות. כדי להשלים מטלות מדורגות במסגרת קורס זה, תוכל לשדרג עוד היום. </string>
     <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
     <string name="course_dates_banner_upgrade_to_graded_button">שדרג עכשיו</string>
-    <!-- Message Course Dashboard Banner Upgrade to Reset -->
-    <string name="course_dashboard_banner_upgrade_to_reset"><b>אתה מבקר את הקורס הזה,</b>
-        מה שאומר שאינך יכול להשתתף במטלות מדורגות. נראה שהחמצת כמה מועדים חשובים בהתבסס על לוח הזמנים המוצע שלנו. כדי להשלים מטלות מדורגות כחלק מהקורס הזה ולהעביר את המטלות שנקבעו בעבר אל העתיד, אתה יכול לשדרג היום. </string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date"><b>נראה שהחמצת כמה מועדים חשובים בהתבסס על לוח הזמנים המוצע שלנו.</b>
         כדי לשמור על עצמכם על המסלול, תוכלו לעדכן את לוח הזמנים הזה ולהעביר את ההקצאות שהוגשו לעתיד. אל דאגה - לא תאבד שום התקדמות שהשגת כאשר תשנה את תאריכי היעד שלך.</string>

--- a/OpenEdXMobile/res/values-ja/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values-ja/course_banners_strings.xml
@@ -4,14 +4,8 @@
     <string name="course_dashboard_info_banner"><b>スムーズに学習を進められるよう、推奨スケジュールをご用意しています。</b>
         忙しい方も心配無用。自分のペースに合わせて柔軟に学習できるので、万が一予定より遅れても
         その都度、調整が可能です。</string>
-    <!-- Message Course Dashboard Banner Upgrade to Complete Graded -->
-    <string name="course_dashboard_banner_upgrade_to_graded"><b>あなたはこのクラスを聴講しています。</b>
-        採点対象の課題には参加できません。このコースで採点対象の課題を完了するには、アップグレードしてください。</string>
     <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
     <string name="course_dates_banner_upgrade_to_graded_button">今すぐアップグレード</string>
-    <!-- Message Course Dashboard Banner Upgrade to Reset -->
-    <string name="course_dashboard_banner_upgrade_to_reset"><b>あなたはこのクラスを聴講しています。</b>
-        採点対象の課題には参加できません。推奨スケジュールにある重要な期限が守られなかったようです。このコースで採点対象の課題を完了し、過去の期限付き課題を未来日付に移動させるには、アップグレードしてください。</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date"><b>推奨スケジュールにある重要な期限が守られなかったようです。</b>
         このスケジュールを更新し、過去の課題を未来日付に移動させることで、学習を計画通りに進めることができます。期限をずらしてもこれまでの進捗が失われることはありませんので、ご安心ください。</string>

--- a/OpenEdXMobile/res/values-ja/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values-ja/course_banners_strings.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Message Course Dashboard Info Banner -->
-    <string name="course_dashboard_info_banner"><b>スムーズに学習を進められるよう、推奨スケジュールをご用意しています。</b>
-        忙しい方も心配無用。自分のペースに合わせて柔軟に学習できるので、万が一予定より遅れても
-        その都度、調整が可能です。</string>
-    <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
-    <string name="course_dates_banner_upgrade_to_graded_button">今すぐアップグレード</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date"><b>推奨スケジュールにある重要な期限が守られなかったようです。</b>
         このスケジュールを更新し、過去の課題を未来日付に移動させることで、学習を計画通りに進めることができます。期限をずらしてもこれまでの進捗が失われることはありませんので、ご安心ください。</string>

--- a/OpenEdXMobile/res/values-pt-rBR/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values-pt-rBR/course_banners_strings.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Message Course Dashboard Info Banner -->
-    <string name="course_dashboard_info_banner"><b>Criamos uma programação como sugestão para ajudar você a se manter no caminho certo.</b>
-        Mas não se preocupe: ela é flexível, possibilitando que você aprenda no seu próprio ritmo. Se não conseguir se manter em dia com as datas sugeridas,
-        você poderá ajustá-las da forma que for melhor para você.</string>
-    <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
-    <string name="course_dates_banner_upgrade_to_graded_button">Fazer o upgrade agora</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date"><b>Parece que você perdeu alguns prazos importantes baseados em nossa programação sugerida.</b>
 Para se ficar em dia, você pode atualizar esta programação e adiar as tarefas já atrasadas. Não se preocupe – você não perderá o progresso já feito.</string>

--- a/OpenEdXMobile/res/values-pt-rBR/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values-pt-rBR/course_banners_strings.xml
@@ -4,14 +4,8 @@
     <string name="course_dashboard_info_banner"><b>Criamos uma programação como sugestão para ajudar você a se manter no caminho certo.</b>
         Mas não se preocupe: ela é flexível, possibilitando que você aprenda no seu próprio ritmo. Se não conseguir se manter em dia com as datas sugeridas,
         você poderá ajustá-las da forma que for melhor para você.</string>
-    <!-- Message Course Dashboard Banner Upgrade to Complete Graded -->
-    <string name="course_dashboard_banner_upgrade_to_graded"><b>Você está participando deste curso,</b>
-o que significa que você não pode participar em avaliações. Para completar avaliações como uma parte deste curso, faça o upgrade hoje.</string>
     <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
     <string name="course_dates_banner_upgrade_to_graded_button">Fazer o upgrade agora</string>
-    <!-- Message Course Dashboard Banner Upgrade to Reset -->
-    <string name="course_dashboard_banner_upgrade_to_reset"><b>Você está participando deste curso,</b>
-o que significa que você não pode participar em avaliações. Para completar avaliações como uma parte deste curso, faça o upgrade hoje. Parece que você perdeu alguns prazos importantes baseados em nossa programação sugerida. Para completar avaliações como parte deste curso e adiar tarefas já atrasadas, faça o upgrade hoje.</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date"><b>Parece que você perdeu alguns prazos importantes baseados em nossa programação sugerida.</b>
 Para se ficar em dia, você pode atualizar esta programação e adiar as tarefas já atrasadas. Não se preocupe – você não perderá o progresso já feito.</string>

--- a/OpenEdXMobile/res/values-tr/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values-tr/course_banners_strings.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Message Course Dashboard Info Banner -->
-    <string name="course_dashboard_info_banner"><b>Öğreniminizin planlandığı gibi gitmesine yardımcı olmak için önerilen bir program oluşturduk.</b>
-        Ancak endişelenmeyin, bu esnek bir program olduğu için kendi hızınızda öğrenebilirsiniz. Önerdiğimiz tarihlerin gerisinde kalırsanız
-        bunları plana uygun kalmanızı sağlayacak şekilde ayarlayabileceksiniz.</string>
-    <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
-    <string name="course_dates_banner_upgrade_to_graded_button">Şimdi yükselt</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date"><b>Önerilen programımıza göre bazı önemli son tarihleri kaçırmışsınız gibi görünüyor.</b>
         Plana uygun kalmak için bu programı güncelleyebilir ve tarihi geçmiş ödevleri geleceğe taşıyabilirsiniz. Endişelenmeyin, bitiş tarihlerinizi değiştirdiğinizde ilerlemenizin hiçbir kısmını kaybetmeyeceksiniz.</string>

--- a/OpenEdXMobile/res/values-tr/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values-tr/course_banners_strings.xml
@@ -4,14 +4,8 @@
     <string name="course_dashboard_info_banner"><b>Öğreniminizin planlandığı gibi gitmesine yardımcı olmak için önerilen bir program oluşturduk.</b>
         Ancak endişelenmeyin, bu esnek bir program olduğu için kendi hızınızda öğrenebilirsiniz. Önerdiğimiz tarihlerin gerisinde kalırsanız
         bunları plana uygun kalmanızı sağlayacak şekilde ayarlayabileceksiniz.</string>
-    <!-- Message Course Dashboard Banner Upgrade to Complete Graded -->
-    <string name="course_dashboard_banner_upgrade_to_graded"><b>Bu kursu denetlemektesiniz,</b>
-        dolayısıyla notlu ödevlere katılamazsınız. Bu kursun parçası olarak notlu ödevler tamamlamak için bugün yükseltme yapabilirsiniz.</string>
     <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
     <string name="course_dates_banner_upgrade_to_graded_button">Şimdi yükselt</string>
-    <!-- Message Course Dashboard Banner Upgrade to Reset -->
-    <string name="course_dashboard_banner_upgrade_to_reset"><b>Bu kursu denetlemektesiniz,</b>
-dolayısıyla notlu ödevlere katılamazsınız. Önerilen programımıza göre bazı önemli son tarihleri kaçırmışsınız gibi görünüyor. Bu kursun parçası olarak notlu ödevler tamamlamak ve tarihi geçmiş ödevleri geleceğe taşımak için bugün yükseltme yapabilirsiniz.</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date"><b>Önerilen programımıza göre bazı önemli son tarihleri kaçırmışsınız gibi görünüyor.</b>
         Plana uygun kalmak için bu programı güncelleyebilir ve tarihi geçmiş ödevleri geleceğe taşıyabilirsiniz. Endişelenmeyin, bitiş tarihlerinizi değiştirdiğinizde ilerlemenizin hiçbir kısmını kaybetmeyeceksiniz.</string>

--- a/OpenEdXMobile/res/values-vi/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values-vi/course_banners_strings.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Message Course Dashboard Info Banner -->
-    <string name="course_dashboard_info_banner"><b>Chúng tôi đã xây dựng một lịch biểu gợi ý để giúp bạn đi đúng hướng.</b>
-        Nhưng đừng lo lắng—lịch biểu rất linh hoạt nên bạn có thể học theo tốc độ của riêng mình. Nếu bạn vô tình bị tụt lại sau những mốc thời gian mà chúng tôi đề xuất,
-        bạn sẽ có thể điều chỉnh các mốc đó để bạn luôn đi đúng hướng.</string>
-    <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
-    <string name="course_dates_banner_upgrade_to_graded_button">Nâng cấp ngay</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date"><b>Có vẻ như bạn đã bỏ lỡ một số hạn chót quan trọng dựa trên lịch biểu gợi ý của chúng tôi.</b>
         Để duy trì đúng hướng đi, bạn có thể cập nhật lịch biểu này và di chuyển các bài tập đã quá hạn đến tương lai. Đừng lo lắng—bạn sẽ không mất bất kỳ tiến bộ nào mà bạn đã đạt được khi di chuyển ngày đến hạn.</string>

--- a/OpenEdXMobile/res/values-vi/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values-vi/course_banners_strings.xml
@@ -4,14 +4,8 @@
     <string name="course_dashboard_info_banner"><b>Chúng tôi đã xây dựng một lịch biểu gợi ý để giúp bạn đi đúng hướng.</b>
         Nhưng đừng lo lắng—lịch biểu rất linh hoạt nên bạn có thể học theo tốc độ của riêng mình. Nếu bạn vô tình bị tụt lại sau những mốc thời gian mà chúng tôi đề xuất,
         bạn sẽ có thể điều chỉnh các mốc đó để bạn luôn đi đúng hướng.</string>
-    <!-- Message Course Dashboard Banner Upgrade to Complete Graded -->
-    <string name="course_dashboard_banner_upgrade_to_graded"><b>Bạn đang dự thính khóa học này,</b>
-        điều này có nghĩa là bạn không thể tham gia vào các bài tập chấm điểm. Để hoàn thành các bài tập chấm điểm thuộc khóa học này, bạn có thể nâng cấp hôm nay.</string>
     <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
     <string name="course_dates_banner_upgrade_to_graded_button">Nâng cấp ngay</string>
-    <!-- Message Course Dashboard Banner Upgrade to Reset -->
-    <string name="course_dashboard_banner_upgrade_to_reset"><b>Bạn đang dự thính khóa học này,</b>
-        điều này có nghĩa là bạn không thể tham gia vào các bài tập chấm điểm. Có vẻ như bạn đã bỏ lỡ một số hạn chót quan trọng dựa trên lịch biểu gợi ý của chúng tôi. Để hoàn thành các bài tập chấm điểm thuộc khóa học này và di chuyển các bài tập đã quá hạn đến tương lai, bạn có thể nâng cấp hôm nay.</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date"><b>Có vẻ như bạn đã bỏ lỡ một số hạn chót quan trọng dựa trên lịch biểu gợi ý của chúng tôi.</b>
         Để duy trì đúng hướng đi, bạn có thể cập nhật lịch biểu này và di chuyển các bài tập đã quá hạn đến tương lai. Đừng lo lắng—bạn sẽ không mất bất kỳ tiến bộ nào mà bạn đã đạt được khi di chuyển ngày đến hạn.</string>

--- a/OpenEdXMobile/res/values-zh/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values-zh/course_banners_strings.xml
@@ -4,14 +4,8 @@
     <string name="course_dashboard_info_banner"><b>我们制定了一个建议的时间表，以帮助您保持合理进度。</b>
         它很灵活，所以您可以按照自己的节奏学习。 如果您碰巧落后于我们建议的日期，
         您可以调整日期，让自己的学习保持进度。</string>
-    <!-- Message Course Dashboard Banner Upgrade to Complete Graded -->
-    <string name="course_dashboard_banner_upgrade_to_graded"><b> 您正在以审阅模式访问本课程，</b>
-这意味着你不能参加分级作业。要完成本课程一部分的分级作业，您可以今天进行功能升级。</string>
     <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
     <string name="course_dates_banner_upgrade_to_graded_button">立即升级</string>
-    <!-- Message Course Dashboard Banner Upgrade to Reset -->
-    <string name="course_dashboard_banner_upgrade_to_reset"><b>您正在以审阅模式访问本课程，</b>
- 这意味着你不能参加分级作业。根据我们建议的日程安排，您似乎错过了一些重要的截止日期。要完成本课程一部分的分级作业，并将过去到期的作业转移到未来，您可以今天进行功能升级。</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date"><b>根据我们建议的日程安排，您似乎错过了一些重要的截止日期。</b>
         为了让自己赶上进程，您可以更新此计划并将过期的任务转移到未来。不要担心，当你改变你的截止日期时，你不会失去你已经取得的任何过程记录。</string>

--- a/OpenEdXMobile/res/values-zh/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values-zh/course_banners_strings.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Message Course Dashboard Info Banner -->
-    <string name="course_dashboard_info_banner"><b>我们制定了一个建议的时间表，以帮助您保持合理进度。</b>
-        它很灵活，所以您可以按照自己的节奏学习。 如果您碰巧落后于我们建议的日期，
-        您可以调整日期，让自己的学习保持进度。</string>
-    <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
-    <string name="course_dates_banner_upgrade_to_graded_button">立即升级</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date"><b>根据我们建议的日程安排，您似乎错过了一些重要的截止日期。</b>
         为了让自己赶上进程，您可以更新此计划并将过期的任务转移到未来。不要担心，当你改变你的截止日期时，你不会失去你已经取得的任何过程记录。</string>

--- a/OpenEdXMobile/res/values/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values/course_banners_strings.xml
@@ -4,14 +4,8 @@
     <string name="course_dashboard_info_banner"><b>We\'ve built a suggested schedule to help you stay on track.</b>
         But don\'t worry—it\'s flexible so you can learn at your own pace. If you happen to fall behind on our suggested dates,
         you\'ll be able to adjust them to keep yourself on track.</string>
-    <!-- Message Course Dashboard Banner Upgrade to Complete Graded -->
-    <string name="course_dashboard_banner_upgrade_to_graded"><b>You are auditing this course,</b>
-        which means that you are unable to participate in graded assignments. To complete graded assignments as part of this course, you can upgrade today.</string>
     <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
     <string name="course_dates_banner_upgrade_to_graded_button">Upgrade now</string>
-    <!-- Message Course Dashboard Banner Upgrade to Reset -->
-    <string name="course_dashboard_banner_upgrade_to_reset"><b>You are auditing this course,</b>
-        which means that you are unable to participate in graded assignments. It looks like you missed some important deadlines based on our suggested schedule. To complete graded assignments as part of this course and shift the past due assignments into the future, you can upgrade today.</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date"><b>It looks like you missed some important deadlines based on our suggested schedule.</b>
         To keep yourself on track, you can update this schedule and shift the past due assignments into the future. Don’t worry—you won’t lose any of the progress you’ve made when you shift your due dates.</string>

--- a/OpenEdXMobile/res/values/course_banners_strings.xml
+++ b/OpenEdXMobile/res/values/course_banners_strings.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Message Course Dashboard Info Banner -->
-    <string name="course_dashboard_info_banner"><b>We\'ve built a suggested schedule to help you stay on track.</b>
-        But don\'t worry—it\'s flexible so you can learn at your own pace. If you happen to fall behind on our suggested dates,
-        you\'ll be able to adjust them to keep yourself on track.</string>
-    <!-- Label Course Dashboard Banner Upgrade to Complete Graded Button -->
-    <string name="course_dates_banner_upgrade_to_graded_button">Upgrade now</string>
     <!-- Message Course Dashboard Banner Reset Date -->
     <string name="course_dashboard_banner_reset_date"><b>It looks like you missed some important deadlines based on our suggested schedule.</b>
         To keep yourself on track, you can update this schedule and shift the past due assignments into the future. Don’t worry—you won’t lose any of the progress you’ve made when you shift your due dates.</string>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/notifications/SnackbarErrorNotification.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/notifications/SnackbarErrorNotification.java
@@ -116,7 +116,7 @@ public class SnackbarErrorNotification extends ErrorNotification {
      * @param errorResId The resource ID of the error message.
      */
     public void showError(int errorResId) {
-        showError(errorResId, 0, 0, Snackbar.LENGTH_SHORT, null);
+        showError(errorResId, 0, 0, Snackbar.LENGTH_LONG, null);
     }
 
     /**

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/notifications/SnackbarErrorNotification.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/notifications/SnackbarErrorNotification.java
@@ -112,12 +112,12 @@ public class SnackbarErrorNotification extends ErrorNotification {
     }
 
     /**
-     * Show the error notification as a persistent Snackbar, according to the provided details.
+     * Show the notification as a persistent Snackbar, according to the provided details.
      *
-     * @param errorResId The resource ID of the error message.
+     * @param stringResId The string resource ID of the message.
      */
-    public void showError(int errorResId) {
-        showError(errorResId, 0, 0, COURSE_UPGRADE_SUCCESS_MESSAGE_DURATION, null);
+    public void showUpgradeSuccessSnackbar(int stringResId) {
+        showError(stringResId, 0, 0, COURSE_UPGRADE_SUCCESS_MESSAGE_DURATION, null);
     }
 
     /**

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/notifications/SnackbarErrorNotification.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/notifications/SnackbarErrorNotification.java
@@ -34,6 +34,7 @@ public class SnackbarErrorNotification extends ErrorNotification {
     private Snackbar snackbar = null;
 
     public static int COURSE_DATE_MESSAGE_DURATION = 5000;
+    public static int COURSE_UPGRADE_SUCCESS_MESSAGE_DURATION = 3000;
 
     /**
      * Construct a new instance of the notification.
@@ -116,7 +117,7 @@ public class SnackbarErrorNotification extends ErrorNotification {
      * @param errorResId The resource ID of the error message.
      */
     public void showError(int errorResId) {
-        showError(errorResId, 0, 0, Snackbar.LENGTH_LONG, null);
+        showError(errorResId, 0, 0, COURSE_UPGRADE_SUCCESS_MESSAGE_DURATION, null);
     }
 
     /**

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/EnrolledCoursesResponse.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/EnrolledCoursesResponse.kt
@@ -44,9 +44,6 @@ data class EnrolledCoursesResponse(
     val isAuditMode: Boolean
         get() = EnrollmentMode.AUDIT.toString().equals(mode, ignoreCase = true)
 
-    val isVerifiedMode: Boolean
-        get() = EnrollmentMode.VERIFIED.toString().equals(mode, ignoreCase = true)
-
     val isUpgradeable: Boolean
         get() = isAuditMode &&
                 course.isStarted &&

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/EnrolledCoursesResponse.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/EnrolledCoursesResponse.kt
@@ -44,6 +44,9 @@ data class EnrolledCoursesResponse(
     val isAuditMode: Boolean
         get() = EnrollmentMode.AUDIT.toString().equals(mode, ignoreCase = true)
 
+    val isVerifiedMode: Boolean
+        get() = EnrollmentMode.VERIFIED.toString().equals(mode, ignoreCase = true)
+
     val isUpgradeable: Boolean
         get() = isAuditMode &&
                 course.isStarted &&

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/CourseDateUtil.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/CourseDateUtil.kt
@@ -36,62 +36,54 @@ object CourseDateUtil {
         val bannerMessage = view.findViewById(R.id.banner_info) as TextView
         val imgView = view.findViewById(R.id.iv_calender) as ImageView
         val button = view.findViewById(R.id.btn_shift_dates) as Button
+        var description = ""
         var buttonText = ""
         var bannerTypeValue = ""
         var biValue = ""
         val bannerType: CourseBannerType = courseBannerInfoModel.datesBannerInfo.getCourseBannerType()
-        // Currently we are only handling RESET_DATES case,
-        // TODO UPGRADE_TO_GRADED & UPGRADE_TO_RESET will be enable once we are allowed to do payment through mobile
+
         if (isCourseDatePage) {
             title.visibility = View.VISIBLE
             containerLayout.setBackgroundColor(Color.TRANSPARENT)
-        }
 
-        if (isCourseDatePage) {
             when (bannerType) {
                 CourseBannerType.UPGRADE_TO_GRADED -> {
-                    bannerMessage.text = context.getText(R.string.course_dates_banner_upgrade_to_graded)
+                    description = context.getString(R.string.course_dates_banner_upgrade_to_graded)
                     biValue = Analytics.Values.COURSE_DATES_BANNER_UPGRADE_TO_PARTICIPATE
                     bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_UPGRADE_TO_PARTICIPATE
                 }
                 CourseBannerType.UPGRADE_TO_RESET -> {
-                    bannerMessage.text = context.getText(R.string.course_dates_banner_upgrade_to_reset)
+                    description = context.getString(R.string.course_dates_banner_upgrade_to_reset)
                     biValue = Analytics.Values.COURSE_DATES_BANNER_UPGRADE_TO_SHIFT
                     bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_UPGRADE_TO_SHIFT
                 }
                 CourseBannerType.RESET_DATES -> {
-                    bannerMessage.text = context.getText(R.string.course_dates_banner_reset_date)
+                    description = context.getString(R.string.course_dates_banner_reset_date)
                     buttonText = context.getString(R.string.course_dates_banner_reset_date_button)
                     biValue = Analytics.Values.COURSE_DATES_BANNER_SHIFT_DATES
                     bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_SHIFT_DATES
                 }
                 CourseBannerType.INFO_BANNER -> {
-                    bannerMessage.text = context.getText(R.string.course_dates_info_banner)
+                    description = context.getString(R.string.course_dates_info_banner)
                     biValue = Analytics.Values.COURSE_DATES_BANNER_INFO
                     bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_INFO
                 }
-                CourseBannerType.BLANK -> view.visibility = View.GONE
+                CourseBannerType.BLANK -> description = ""
             }
-        }
-        else {
+        } else {
             when (bannerType) {
                 CourseBannerType.RESET_DATES -> {
-                    bannerMessage.text = context.getText(R.string.course_dashboard_banner_reset_date)
+                    description = context.getString(R.string.course_dashboard_banner_reset_date)
                     buttonText = context.getString(R.string.course_dates_banner_reset_date_button)
                     biValue = Analytics.Values.COURSE_DATES_BANNER_SHIFT_DATES
                     bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_SHIFT_DATES
                 }
-                CourseBannerType.INFO_BANNER -> {
-                    bannerMessage.text = context.getText(R.string.course_dashboard_info_banner)
-                    biValue = Analytics.Values.COURSE_DATES_BANNER_INFO
-                    bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_INFO
-                }
-                CourseBannerType.BLANK -> view.visibility = View.GONE
-                else -> view.visibility = View.GONE
+                else -> description = ""
             }
         }
 
-        if (!TextUtils.isEmpty(bannerMessage.text) && (isSelfPaced || (isSelfPaced.not() && bannerType == CourseBannerType.UPGRADE_TO_GRADED))) {
+        if (description.isNotBlank() && (isSelfPaced || (isSelfPaced.not() && bannerType == CourseBannerType.UPGRADE_TO_GRADED))) {
+            bannerMessage.text = description
             if (!TextUtils.isEmpty(buttonText)) {
                 button.text = buttonText
                 button.visibility = View.VISIBLE

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/CourseDateUtil.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/CourseDateUtil.kt
@@ -36,7 +36,7 @@ object CourseDateUtil {
         val bannerMessage = view.findViewById(R.id.banner_info) as TextView
         val imgView = view.findViewById(R.id.iv_calender) as ImageView
         val button = view.findViewById(R.id.btn_shift_dates) as Button
-        var description = ""
+        var description: CharSequence = ""
         var buttonText = ""
         var bannerTypeValue = ""
         var biValue = ""
@@ -48,23 +48,23 @@ object CourseDateUtil {
 
             when (bannerType) {
                 CourseBannerType.UPGRADE_TO_GRADED -> {
-                    description = context.getString(R.string.course_dates_banner_upgrade_to_graded)
+                    description = context.getText(R.string.course_dates_banner_upgrade_to_graded)
                     biValue = Analytics.Values.COURSE_DATES_BANNER_UPGRADE_TO_PARTICIPATE
                     bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_UPGRADE_TO_PARTICIPATE
                 }
                 CourseBannerType.UPGRADE_TO_RESET -> {
-                    description = context.getString(R.string.course_dates_banner_upgrade_to_reset)
+                    description = context.getText(R.string.course_dates_banner_upgrade_to_reset)
                     biValue = Analytics.Values.COURSE_DATES_BANNER_UPGRADE_TO_SHIFT
                     bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_UPGRADE_TO_SHIFT
                 }
                 CourseBannerType.RESET_DATES -> {
-                    description = context.getString(R.string.course_dates_banner_reset_date)
+                    description = context.getText(R.string.course_dates_banner_reset_date)
                     buttonText = context.getString(R.string.course_dates_banner_reset_date_button)
                     biValue = Analytics.Values.COURSE_DATES_BANNER_SHIFT_DATES
                     bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_SHIFT_DATES
                 }
                 CourseBannerType.INFO_BANNER -> {
-                    description = context.getString(R.string.course_dates_info_banner)
+                    description = context.getText(R.string.course_dates_info_banner)
                     biValue = Analytics.Values.COURSE_DATES_BANNER_INFO
                     bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_INFO
                 }
@@ -73,7 +73,7 @@ object CourseDateUtil {
         } else {
             when (bannerType) {
                 CourseBannerType.RESET_DATES -> {
-                    description = context.getString(R.string.course_dashboard_banner_reset_date)
+                    description = context.getText(R.string.course_dashboard_banner_reset_date)
                     buttonText = context.getString(R.string.course_dates_banner_reset_date_button)
                     biValue = Analytics.Values.COURSE_DATES_BANNER_SHIFT_DATES
                     bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_SHIFT_DATES

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/CourseDateUtil.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/CourseDateUtil.kt
@@ -46,29 +46,49 @@ object CourseDateUtil {
             title.visibility = View.VISIBLE
             containerLayout.setBackgroundColor(Color.TRANSPARENT)
         }
-        when (bannerType) {
-            CourseBannerType.UPGRADE_TO_GRADED -> {
-                bannerMessage.text = context.getText(if (isCourseDatePage) R.string.course_dates_banner_upgrade_to_graded else R.string.course_dashboard_banner_upgrade_to_graded)
-                biValue = Analytics.Values.COURSE_DATES_BANNER_UPGRADE_TO_PARTICIPATE
-                bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_UPGRADE_TO_PARTICIPATE
+
+        if (isCourseDatePage) {
+            when (bannerType) {
+                CourseBannerType.UPGRADE_TO_GRADED -> {
+                    bannerMessage.text = context.getText(R.string.course_dates_banner_upgrade_to_graded)
+                    biValue = Analytics.Values.COURSE_DATES_BANNER_UPGRADE_TO_PARTICIPATE
+                    bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_UPGRADE_TO_PARTICIPATE
+                }
+                CourseBannerType.UPGRADE_TO_RESET -> {
+                    bannerMessage.text = context.getText(R.string.course_dates_banner_upgrade_to_reset)
+                    biValue = Analytics.Values.COURSE_DATES_BANNER_UPGRADE_TO_SHIFT
+                    bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_UPGRADE_TO_SHIFT
+                }
+                CourseBannerType.RESET_DATES -> {
+                    bannerMessage.text = context.getText(R.string.course_dates_banner_reset_date)
+                    buttonText = context.getString(R.string.course_dates_banner_reset_date_button)
+                    biValue = Analytics.Values.COURSE_DATES_BANNER_SHIFT_DATES
+                    bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_SHIFT_DATES
+                }
+                CourseBannerType.INFO_BANNER -> {
+                    bannerMessage.text = context.getText(R.string.course_dates_info_banner)
+                    biValue = Analytics.Values.COURSE_DATES_BANNER_INFO
+                    bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_INFO
+                }
+                CourseBannerType.BLANK -> view.visibility = View.GONE
             }
-            CourseBannerType.UPGRADE_TO_RESET -> {
-                bannerMessage.text = context.getText(if (isCourseDatePage) R.string.course_dates_banner_upgrade_to_reset else R.string.course_dashboard_banner_upgrade_to_reset)
-                biValue = Analytics.Values.COURSE_DATES_BANNER_UPGRADE_TO_SHIFT
-                bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_UPGRADE_TO_SHIFT
+        }
+        else {
+            when (bannerType) {
+                CourseBannerType.RESET_DATES -> {
+                    bannerMessage.text = context.getText(R.string.course_dashboard_banner_reset_date)
+                    buttonText = context.getString(R.string.course_dates_banner_reset_date_button)
+                    biValue = Analytics.Values.COURSE_DATES_BANNER_SHIFT_DATES
+                    bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_SHIFT_DATES
+                }
+                CourseBannerType.INFO_BANNER -> {
+                    bannerMessage.text = context.getText(R.string.course_dashboard_info_banner)
+                    biValue = Analytics.Values.COURSE_DATES_BANNER_INFO
+                    bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_INFO
+                }
+                CourseBannerType.BLANK -> view.visibility = View.GONE
+                else -> view.visibility = View.GONE
             }
-            CourseBannerType.RESET_DATES -> {
-                bannerMessage.text = context.getText(if (isCourseDatePage) R.string.course_dates_banner_reset_date else R.string.course_dashboard_banner_reset_date)
-                buttonText = context.getString(R.string.course_dates_banner_reset_date_button)
-                biValue = Analytics.Values.COURSE_DATES_BANNER_SHIFT_DATES
-                bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_SHIFT_DATES
-            }
-            CourseBannerType.INFO_BANNER -> {
-                bannerMessage.text = context.getText(if (isCourseDatePage) R.string.course_dates_info_banner else R.string.course_dashboard_info_banner)
-                biValue = Analytics.Values.COURSE_DATES_BANNER_INFO
-                bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_INFO
-            }
-            CourseBannerType.BLANK -> view.visibility = View.GONE
         }
 
         if (!TextUtils.isEmpty(bannerMessage.text) && (isSelfPaced || (isSelfPaced.not() && bannerType == CourseBannerType.UPGRADE_TO_GRADED))) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/CourseDateUtil.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/CourseDateUtil.kt
@@ -19,17 +19,35 @@ import org.edx.mobile.module.analytics.AnalyticsRegistry
  */
 object CourseDateUtil {
 
-    fun setupCourseDatesBanner(view: View, courseId: String, enrollmentMode: String, isSelfPaced: Boolean,
-                               screenName: String, analyticsRegistry: AnalyticsRegistry,
-                               courseBannerInfoModel: CourseBannerInfoModel, clickListener: View.OnClickListener) {
-        setupCourseDatesBanner(view = view, isCourseDatePage = false, courseId = courseId, enrollmentMode = enrollmentMode,
-                isSelfPaced = isSelfPaced, screenName = screenName, analyticsRegistry = analyticsRegistry,
-                courseBannerInfoModel = courseBannerInfoModel, clickListener = clickListener)
+    fun setupCourseDatesBanner(
+        view: View, courseId: String, enrollmentMode: String, isSelfPaced: Boolean,
+        screenName: String, analyticsRegistry: AnalyticsRegistry,
+        courseBannerInfoModel: CourseBannerInfoModel, clickListener: View.OnClickListener
+    ) {
+        setupCourseDatesBanner(
+            view = view,
+            isCourseDatePage = false,
+            courseId = courseId,
+            enrollmentMode = enrollmentMode,
+            isSelfPaced = isSelfPaced,
+            screenName = screenName,
+            analyticsRegistry = analyticsRegistry,
+            courseBannerInfoModel = courseBannerInfoModel,
+            clickListener = clickListener
+        )
     }
 
-    fun setupCourseDatesBanner(view: View, isCourseDatePage: Boolean, courseId: String, enrollmentMode: String, isSelfPaced: Boolean,
-                               screenName: String, analyticsRegistry: AnalyticsRegistry,
-                               courseBannerInfoModel: CourseBannerInfoModel, clickListener: View.OnClickListener) {
+    fun setupCourseDatesBanner(
+        view: View,
+        isCourseDatePage: Boolean,
+        courseId: String,
+        enrollmentMode: String,
+        isSelfPaced: Boolean,
+        screenName: String,
+        analyticsRegistry: AnalyticsRegistry,
+        courseBannerInfoModel: CourseBannerInfoModel,
+        clickListener: View.OnClickListener
+    ) {
         val context = view.context as Context
         val containerLayout = view as LinearLayout
         val title = view.findViewById(R.id.banner_title) as TextView
@@ -40,7 +58,7 @@ object CourseDateUtil {
         var buttonText = ""
         var bannerTypeValue = ""
         var biValue = ""
-        val bannerType: CourseBannerType = courseBannerInfoModel.datesBannerInfo.getCourseBannerType()
+        val bannerType = courseBannerInfoModel.datesBannerInfo.getCourseBannerType()
 
         if (isCourseDatePage) {
             title.visibility = View.VISIBLE
@@ -70,16 +88,11 @@ object CourseDateUtil {
                 }
                 CourseBannerType.BLANK -> description = ""
             }
-        } else {
-            when (bannerType) {
-                CourseBannerType.RESET_DATES -> {
-                    description = context.getText(R.string.course_dashboard_banner_reset_date)
-                    buttonText = context.getString(R.string.course_dates_banner_reset_date_button)
-                    biValue = Analytics.Values.COURSE_DATES_BANNER_SHIFT_DATES
-                    bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_SHIFT_DATES
-                }
-                else -> description = ""
-            }
+        } else if (bannerType == CourseBannerType.RESET_DATES) {
+            description = context.getText(R.string.course_dashboard_banner_reset_date)
+            buttonText = context.getString(R.string.course_dates_banner_reset_date_button)
+            biValue = Analytics.Values.COURSE_DATES_BANNER_SHIFT_DATES
+            bannerTypeValue = Analytics.Values.PLS_BANNER_TYPE_SHIFT_DATES
         }
 
         if (description.isNotBlank() && (isSelfPaced || (isSelfPaced.not() && bannerType == CourseBannerType.UPGRADE_TO_GRADED))) {
@@ -90,14 +103,24 @@ object CourseDateUtil {
                 imgView.visibility = if (isCourseDatePage) View.GONE else View.VISIBLE
                 button.setOnClickListener { v ->
                     clickListener.onClick(v)
-                    analyticsRegistry.trackPLSShiftButtonTapped(courseId, enrollmentMode, screenName)
+                    analyticsRegistry.trackPLSShiftButtonTapped(
+                        courseId,
+                        enrollmentMode,
+                        screenName
+                    )
                 }
             } else {
                 button.visibility = View.GONE
                 imgView.visibility = View.GONE
             }
             view.visibility = View.VISIBLE
-            analyticsRegistry.trackPLSCourseDatesBanner(biValue, courseId, enrollmentMode, screenName, bannerTypeValue)
+            analyticsRegistry.trackPLSCourseDatesBanner(
+                biValue,
+                courseId,
+                enrollmentMode,
+                screenName,
+                bannerTypeValue
+            )
         } else {
             view.visibility = View.GONE
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -634,7 +634,8 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
             if (listView.getHeaderViewsCount() == 0 && bannerViewBinding.getRoot().getVisibility() == View.VISIBLE) {
                 listView.addHeaderView(bannerViewBinding.getRoot());
                 isBannerVisible = true;
-            } else if (EnrollmentMode.VERIFIED.toString().equalsIgnoreCase(courseData.getMode())) {
+            } else if (EnrollmentMode.VERIFIED.toString().equalsIgnoreCase(courseData.getMode()) ||
+                    bannerViewBinding.getRoot().getVisibility() != View.VISIBLE) {
                 listView.removeHeaderView(bannerViewBinding.getRoot());
                 isBannerVisible = false;
             }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -66,6 +66,7 @@ import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.model.api.ProfileModel;
 import org.edx.mobile.model.course.BlockPath;
 import org.edx.mobile.model.course.CourseBannerInfoModel;
+import org.edx.mobile.model.course.CourseBannerType;
 import org.edx.mobile.model.course.CourseComponent;
 import org.edx.mobile.model.course.CourseStructureV1Model;
 import org.edx.mobile.model.course.EnrollmentMode;
@@ -626,18 +627,17 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
         if (bannerViewBinding == null)
             bannerViewBinding = LayoutCourseDatesBannerBinding.inflate(getLayoutInflater(), listView, false);
 
-        if (courseBannerInfo != null && !isVideoMode && isOnCourseOutline && !courseBannerInfo.getHasEnded()) {
+        if (courseBannerInfo != null && !isVideoMode && isOnCourseOutline && !courseBannerInfo.getHasEnded() &&
+                courseBannerInfo.getDatesBannerInfo().getCourseBannerType() == CourseBannerType.RESET_DATES) {
+
             CourseDateUtil.INSTANCE.setupCourseDatesBanner(bannerViewBinding.getRoot(),
                     courseData.getCourse().getId(), courseData.getMode(), courseData.getCourse().isSelfPaced(),
                     Analytics.Screens.PLS_COURSE_DASHBOARD, environment.getAnalyticsRegistry(), courseBannerInfo,
                     v -> courseDateViewModel.resetCourseDatesBanner(courseData.getCourseId()));
 
-            if (listView.getHeaderViewsCount() == 0 && bannerViewBinding.getRoot().getVisibility() == View.VISIBLE) {
+            if (listView.getHeaderViewsCount() == 0 && ViewExtKt.isVisible(bannerViewBinding.getRoot())) {
                 listView.addHeaderView(bannerViewBinding.getRoot());
                 isBannerVisible = true;
-            } else if (courseData.isVerifiedMode() || !ViewExtKt.isVisible(bannerViewBinding.getRoot())) {
-                listView.removeHeaderView(bannerViewBinding.getRoot());
-                isBannerVisible = false;
             }
         } else {
             listView.removeHeaderView(bannerViewBinding.getRoot());

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -50,6 +50,7 @@ import org.edx.mobile.event.MediaStatusChangeEvent;
 import org.edx.mobile.event.NetworkConnectivityChangeEvent;
 import org.edx.mobile.exception.CourseContentNotValidException;
 import org.edx.mobile.exception.ErrorMessage;
+import org.edx.mobile.extenstion.ViewExtKt;
 import org.edx.mobile.http.HttpStatus;
 import org.edx.mobile.http.HttpStatusException;
 import org.edx.mobile.http.callback.ErrorHandlingCallback;
@@ -483,7 +484,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
                 FullscreenLoaderDialogFragment fullscreenLoader = FullscreenLoaderDialogFragment
                         .getRetainedInstance(getChildFragmentManager());
                 if (fullscreenLoader != null && fullscreenLoader.isResumed()) {
-                    new SnackbarErrorNotification(listView).showError(R.string.purchase_success_message);
+                    new SnackbarErrorNotification(listView).showUpgradeSuccessSnackbar(R.string.purchase_success_message);
                     fullscreenLoader.closeLoader();
                 }
             }
@@ -634,8 +635,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
             if (listView.getHeaderViewsCount() == 0 && bannerViewBinding.getRoot().getVisibility() == View.VISIBLE) {
                 listView.addHeaderView(bannerViewBinding.getRoot());
                 isBannerVisible = true;
-            } else if (EnrollmentMode.VERIFIED.toString().equalsIgnoreCase(courseData.getMode()) ||
-                    bannerViewBinding.getRoot().getVisibility() != View.VISIBLE) {
+            } else if (courseData.isVerifiedMode() || !ViewExtKt.isVisible(bannerViewBinding.getRoot())) {
                 listView.removeHeaderView(bannerViewBinding.getRoot());
                 isBannerVisible = false;
             }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
@@ -281,7 +281,7 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
         FullscreenLoaderDialogFragment fullScreenLoader = FullscreenLoaderDialogFragment
                 .getRetainedInstance(getSupportFragmentManager());
         if (fullScreenLoader != null && fullScreenLoader.isResumed()) {
-            new SnackbarErrorNotification(pager2).showError(R.string.purchase_success_message);
+            new SnackbarErrorNotification(pager2).showUpgradeSuccessSnackbar(R.string.purchase_success_message);
             fullScreenLoader.closeLoader();
         }
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.kt
@@ -248,7 +248,7 @@ class MyCoursesListFragment : OfflineSupportBaseFragment(), RefreshListener {
             fragmentManager = childFragmentManager
         )
         if (fullscreenLoader != null) {
-            SnackbarErrorNotification(binding.root).showError(R.string.purchase_success_message)
+            SnackbarErrorNotification(binding.root).showUpgradeSuccessSnackbar(R.string.purchase_success_message)
             fullscreenLoader.closeLoader()
         } else {
             iapAnalytics.reset()


### PR DESCRIPTION
### Description

[LEARNER-9256](https://2u-internal.atlassian.net/browse/LEARNER-9256)

- Increase time for Post-purchase upgrade toast i.e 3 secs
- Remove the Upgrade & Info Banner from the Course Home page
- Banners are still available on the Course Dates page