### PR TITLE
feat: Handle external links on the Discovery screen

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/AppConstants.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/AppConstants.java
@@ -40,7 +40,7 @@ public enum AppConstants {
     public static final String PRICE = "price";
 
     public static final String HEADER_KEY_AUTHORIZATION = "Authorization";
-
+    public static final String QUERY_PARAM_EXTERNAL_LINK = "external_link";
     /**
      * This class defines all the Firebase constants related to the app.
      */

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/URLInterceptorWebViewClient.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/URLInterceptorWebViewClient.java
@@ -337,7 +337,7 @@ public class URLInterceptorWebViewClient extends WebViewClient {
             return false;
         }
         final WebViewLink helperObj = WebViewLink.parse(strUrl);
-        if (null == helperObj || Boolean.parseBoolean(helperObj.params.get(AppConstants.QUERY_PARAM_EXTERNAL_LINK))) {
+        if (null == helperObj) {
             return false;
         }
         actionListener.onLinkRecognized(helperObj);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/URLInterceptorWebViewClient.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/URLInterceptorWebViewClient.java
@@ -21,6 +21,7 @@ import org.edx.mobile.http.HttpStatus;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.AjaxCallData;
 import org.edx.mobile.module.analytics.AnalyticsRegistry;
+import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.BrowserUtil;
 import org.edx.mobile.util.Config;
 import org.edx.mobile.util.ConfigUtil;
@@ -310,8 +311,12 @@ public class URLInterceptorWebViewClient extends WebViewClient {
      * @return
      */
     private boolean isExternalLink(String strUrl) {
-        return hostForThisPage != null && strUrl != null &&
-                !hostForThisPage.equals(Uri.parse(strUrl).getHost());
+        if (strUrl != null) {
+            Uri uri = Uri.parse(strUrl);
+            return Boolean.parseBoolean(uri.getQueryParameter(AppConstants.QUERY_PARAM_EXTERNAL_LINK)) ||
+                    (hostForThisPage != null && !hostForThisPage.equals(uri.getHost()));
+        }
+        return false;
     }
 
     /**
@@ -332,7 +337,7 @@ public class URLInterceptorWebViewClient extends WebViewClient {
             return false;
         }
         final WebViewLink helperObj = WebViewLink.parse(strUrl);
-        if (null == helperObj) {
+        if (null == helperObj || Boolean.parseBoolean(helperObj.params.get(AppConstants.QUERY_PARAM_EXTERNAL_LINK))) {
             return false;
         }
         actionListener.onLinkRecognized(helperObj);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/URLInterceptorWebViewClient.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/URLInterceptorWebViewClient.java
@@ -314,7 +314,7 @@ public class URLInterceptorWebViewClient extends WebViewClient {
         if (strUrl != null) {
             Uri uri = Uri.parse(strUrl);
             String externalLinkValue = uri.getQueryParameter(AppConstants.QUERY_PARAM_EXTERNAL_LINK);
-            
+
             return (hostForThisPage != null && !hostForThisPage.equals(uri.getHost())) ||
                     Boolean.parseBoolean(externalLinkValue);
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/URLInterceptorWebViewClient.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/URLInterceptorWebViewClient.java
@@ -313,8 +313,10 @@ public class URLInterceptorWebViewClient extends WebViewClient {
     private boolean isExternalLink(String strUrl) {
         if (strUrl != null) {
             Uri uri = Uri.parse(strUrl);
-            return Boolean.parseBoolean(uri.getQueryParameter(AppConstants.QUERY_PARAM_EXTERNAL_LINK)) ||
-                    (hostForThisPage != null && !hostForThisPage.equals(uri.getHost()));
+            String externalLinkValue = uri.getQueryParameter(AppConstants.QUERY_PARAM_EXTERNAL_LINK);
+            
+            return (hostForThisPage != null && !hostForThisPage.equals(uri.getHost())) ||
+                    Boolean.parseBoolean(externalLinkValue);
         }
         return false;
     }


### PR DESCRIPTION
### Description

[LEARNER-9248](https://2u-internal.atlassian.net/browse/LEARNER-9248)

If any links contain the `external_link` query parameter with the value `true`, we need to show the external link pop-up to the user.
