### PR TITLE
fix: Handle Hierarchical Uris only for external links

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/URLInterceptorWebViewClient.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/URLInterceptorWebViewClient.java
@@ -313,7 +313,10 @@ public class URLInterceptorWebViewClient extends WebViewClient {
     private boolean isExternalLink(String strUrl) {
         if (strUrl != null) {
             Uri uri = Uri.parse(strUrl);
-            String externalLinkValue = uri.getQueryParameter(AppConstants.QUERY_PARAM_EXTERNAL_LINK);
+            String externalLinkValue = null;
+            if (uri.isHierarchical()) {
+                externalLinkValue = uri.getQueryParameter(AppConstants.QUERY_PARAM_EXTERNAL_LINK);
+            }
 
             return (hostForThisPage != null && !hostForThisPage.equals(uri.getHost())) ||
                     Boolean.parseBoolean(externalLinkValue);


### PR DESCRIPTION
### Description

[LEARNER-9272](https://2u-internal.atlassian.net/browse/LEARNER-9272)

Before fetching query parameters, it is advisable to check whether the URI is hierarchical. If the URI is not hierarchical, further processing should be avoided as it will lead to unexpected results. 

A URI is hierarchical if it has a scheme, authority, and path.
