### PR TITLE
feat: Hide Upgrade Button if Course SKU is not available

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.kt
@@ -76,6 +76,9 @@ class CourseUnitMobileNotSupportedFragment : CourseUnitFragment() {
     private fun showGradedContent() {
         unit?.let { unit ->
             val isSelfPaced = getBooleanArgument(Router.EXTRA_IS_SELF_PACED, false)
+            val isPurchaseEnabled = unit.courseSku.isNullOrEmpty().not() &&
+                    environment.appFeaturesPrefs.isIAPEnabled(environment.loginPrefs.isOddUserId)
+
             binding.containerLayoutNotAvailable.setVisibility(false)
             binding.llGradedContentLayout.setVisibility(true)
             var experimentGroup: String? = null
@@ -94,7 +97,7 @@ class CourseUnitMobileNotSupportedFragment : CourseUnitFragment() {
                 experimentGroup,
                 unit.id
             )
-            if (environment.appFeaturesPrefs.isIAPEnabled(environment.loginPrefs.isOddUserId)) {
+            if (isPurchaseEnabled) {
                 iapAnalytics.initCourseValues(
                     courseId = unit.courseId,
                     isSelfPaced = isSelfPaced,

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
@@ -87,8 +87,9 @@ class CourseModalDialogFragment : DialogFragment() {
             KEY_COURSE_NAME,
             arguments?.getString(KEY_COURSE_NAME)
         )
-        val isPurchaseEnabled =
-            environment.appFeaturesPrefs.isIAPEnabled(environment.loginPrefs.isOddUserId)
+        val isPurchaseEnabled = courseSku.isNullOrEmpty().not() &&
+                environment.appFeaturesPrefs.isIAPEnabled(environment.loginPrefs.isOddUserId)
+
         binding.layoutUpgradeBtn.root.setVisibility(isPurchaseEnabled)
         binding.dialogDismiss.setOnClickListener {
             dialog?.dismiss()


### PR DESCRIPTION
Fixes: LEARNER-9285

### Description

[LEARNER-9285](https://2u-internal.atlassian.net/browse/LEARNER-9285)

Hide the Upgrade Button if Android SKU is unavailable in the course enrollments API. 

### Testing
- [ ] Analytics