### PR TITLE
Fix: Error Dialog not Appearing Correctly on Course Component Screen

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
@@ -260,6 +260,9 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
     public void initializeIAPObserver() {
         iapViewModel = new ViewModelProvider(this).get(InAppPurchasesViewModel.class);
 
+        // The shared observer is used to monitor and handle any errors that may occur during the
+        // ‘refreshCourseData’ method, which is called as part of the refresh flow. This observer
+        // invokes the ‘updateCourseStructure’ method within the ‘CourseBaseActivity’.
         iapViewModel.getErrorMessage().observe(this, new NonNullObserver<>(errorMessageEvent -> {
             if (errorMessageEvent.peekContent().getRequestType() == ErrorMessage.COURSE_REFRESH_CODE) {
                 ErrorMessage errorMessage = errorMessageEvent.getContentIfNotConsumed();

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
@@ -42,10 +42,10 @@ import org.edx.mobile.module.analytics.Analytics;
 import org.edx.mobile.module.analytics.InAppPurchasesAnalytics;
 import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.FileUtil;
+import org.edx.mobile.util.NonNullObserver;
 import org.edx.mobile.util.UiUtils;
 import org.edx.mobile.util.VideoUtil;
 import org.edx.mobile.util.images.ShareUtils;
-import org.edx.mobile.util.observer.EventObserver;
 import org.edx.mobile.view.adapters.CourseUnitPagerAdapter;
 import org.edx.mobile.view.custom.PreLoadingListener;
 import org.edx.mobile.view.dialog.CelebratoryModalDialogFragment;
@@ -260,10 +260,11 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
     public void initializeIAPObserver() {
         iapViewModel = new ViewModelProvider(this).get(InAppPurchasesViewModel.class);
 
-        iapViewModel.getErrorMessage().observe(this, new EventObserver<>(errorMessage -> {
-            if (errorMessage.getRequestType() == ErrorMessage.COURSE_REFRESH_CODE) {
+        iapViewModel.getErrorMessage().observe(this, new NonNullObserver<>(errorMessageEvent -> {
+            if (errorMessageEvent.peekContent().getRequestType() == ErrorMessage.COURSE_REFRESH_CODE) {
+                ErrorMessage errorMessage = errorMessageEvent.getContentIfNotConsumed();
                 FullscreenLoaderDialogFragment fullScreenLoader = FullscreenLoaderDialogFragment.getRetainedInstance(getSupportFragmentManager());
-                if (fullScreenLoader == null) {
+                if (fullScreenLoader == null || errorMessage == null) {
                     return null;
                 }
                 iapDialogs.handleIAPException(


### PR DESCRIPTION
### Description

[LEARNER-9314](https://2u-internal.atlassian.net/browse/LEARNER-9314)

The component screen was unable to observe the event because we consumed the shared event on CourseUnitNavigationActivity. This resulted in the event being unavailable for the screen to receive. To prevent a recurrence of this issue, we have taken steps to ensure that events are only consumed if they are specifically related to that screen.
