### PR TITLE
fix: Enrollment API call after purchase.

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/event/MyCoursesRefreshEvent.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/event/MyCoursesRefreshEvent.kt
@@ -1,0 +1,8 @@
+package org.edx.mobile.event
+
+/**
+ * The event to fire through [EventBus][org.greenrobot.eventbus.EventBus] whenever some screen state
+ * needs to refresh on [MyCoursesListFragment][org.edx.mobile.view.MyCoursesListFragment] after in-app
+ * purchase.
+ */
+class MyCoursesRefreshEvent

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/AppFeaturesPrefs.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/AppFeaturesPrefs.kt
@@ -47,4 +47,12 @@ class AppFeaturesPrefs @Inject constructor(@ApplicationContext context: Context)
         }
         return false
     }
+
+    fun canAutoCheckUnfulfilledPurchase(): Boolean {
+        return pref.getBoolean(PrefManager.Key.CHECK_UNFULFILLED_PURCHASE, false)
+    }
+
+    fun setAutoCheckUnfulfilledPurchase(canCheckUnfulfilledPurchase: Boolean) {
+        pref.put(PrefManager.Key.CHECK_UNFULFILLED_PURCHASE, canCheckUnfulfilledPurchase)
+    }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
@@ -307,6 +307,7 @@ public class PrefManager {
         public static final String BULK_DOWNLOAD_FOR_COURSE_ID = "BULK_DOWNLOAD_%s";
         // Preference to save app config
         public static final String APP_CONFIG = "APP_CONFIG";
+        public static final String CHECK_UNFULFILLED_PURCHASE = "CHECK_UNFULFILLED_PURCHASE";
     }
 
     public static final class Value {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/repository/CourseRepository.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/repository/CourseRepository.kt
@@ -24,6 +24,7 @@ class CourseRepository @Inject constructor(
             CoursesRequestType.STALE -> courseAPI.enrolledCourses
             CoursesRequestType.CACHE -> courseAPI.enrolledCoursesFromCache
             CoursesRequestType.LIVE -> courseAPI.enrolledCoursesWithoutStale
+            else -> throw java.lang.Exception("Unknown Request Type: $type")
         }
 
         call.enqueue(object : Callback<EnrollmentResponse> {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/AccountFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/AccountFragment.kt
@@ -22,8 +22,8 @@ import org.edx.mobile.deeplink.Screen
 import org.edx.mobile.deeplink.ScreenDef
 import org.edx.mobile.event.AccountDataLoadedEvent
 import org.edx.mobile.event.IAPFlowEvent
-import org.edx.mobile.event.MainDashboardRefreshEvent
 import org.edx.mobile.event.MediaStatusChangeEvent
+import org.edx.mobile.event.MyCoursesRefreshEvent
 import org.edx.mobile.event.ProfilePhotoUpdatedEvent
 import org.edx.mobile.exception.ErrorMessage
 import org.edx.mobile.extenstion.isVisible
@@ -545,7 +545,7 @@ class AccountFragment : BaseFragment() {
     @SuppressWarnings("unused")
     fun onEventMainThread(event: IAPFlowEvent) {
         if (this.isResumed && event.flowAction == IAPFlowData.IAPAction.PURCHASE_FLOW_COMPLETE) {
-            EventBus.getDefault().post(MainDashboardRefreshEvent())
+            EventBus.getDefault().post(MyCoursesRefreshEvent())
             requireActivity().finish()
         }
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -45,8 +45,8 @@ import org.edx.mobile.event.CourseDashboardRefreshEvent;
 import org.edx.mobile.event.CourseUpgradedEvent;
 import org.edx.mobile.event.IAPFlowEvent;
 import org.edx.mobile.event.LogoutEvent;
-import org.edx.mobile.event.MainDashboardRefreshEvent;
 import org.edx.mobile.event.MediaStatusChangeEvent;
+import org.edx.mobile.event.MyCoursesRefreshEvent;
 import org.edx.mobile.event.NetworkConnectivityChangeEvent;
 import org.edx.mobile.exception.CourseContentNotValidException;
 import org.edx.mobile.exception.ErrorMessage;
@@ -1061,7 +1061,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
                     // Update the User CourseEnrollments & Dates banner if after user
                     // Purchase course from Locked Component
                     courseDateViewModel.fetchCourseDatesBannerInfo(courseData.getCourseId(), true);
-                    EventBus.getDefault().post(new MainDashboardRefreshEvent());
+                    EventBus.getDefault().post(new MyCoursesRefreshEvent());
                 }
             } else {
                 final CourseComponent outlineComp = courseManager.getComponentByIdFromAppLevelCache(
@@ -1138,7 +1138,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
             case PURCHASE_FLOW_COMPLETE: {
                 courseData.setMode(EnrollmentMode.VERIFIED.toString());
                 getCourseComponentFromServer(false, true);
-                EventBus.getDefault().post(new MainDashboardRefreshEvent());
+                EventBus.getDefault().post(new MyCoursesRefreshEvent());
                 break;
             }
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
@@ -27,7 +27,7 @@ import org.edx.mobile.databinding.ViewCourseUnitPagerBinding;
 import org.edx.mobile.event.CourseUpgradedEvent;
 import org.edx.mobile.event.FileSelectionEvent;
 import org.edx.mobile.event.IAPFlowEvent;
-import org.edx.mobile.event.MainDashboardRefreshEvent;
+import org.edx.mobile.event.MyCoursesRefreshEvent;
 import org.edx.mobile.event.VideoPlaybackEvent;
 import org.edx.mobile.exception.ErrorMessage;
 import org.edx.mobile.http.callback.ErrorHandlingCallback;
@@ -496,7 +496,7 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
                 break;
             }
             case PURCHASE_FLOW_COMPLETE: {
-                EventBus.getDefault().post(new MainDashboardRefreshEvent());
+                EventBus.getDefault().post(new MyCoursesRefreshEvent());
                 break;
             }
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.kt
@@ -148,7 +148,17 @@ class MyCoursesListFragment : OfflineSupportBaseFragment(), RefreshListener {
                     environment.appFeaturesPrefs.isIAPEnabled(environment.loginPrefs.isOddUserId)
                 ) {
                     initInAppPurchaseSetup()
-                    detectUnfulfilledPurchase(enrolledCourses)
+                    val fullscreenLoader = FullscreenLoaderDialogFragment.getRetainedInstance(
+                        fragmentManager = childFragmentManager
+                    )
+                    if (fullscreenLoader != null) {
+                        SnackbarErrorNotification(binding.root).showUpgradeSuccessSnackbar(R.string.purchase_success_message)
+                        fullscreenLoader.closeLoader()
+                    } else if (environment.appFeaturesPrefs.canAutoCheckUnfulfilledPurchase() &&
+                        courseViewModel.courseRequestType != CoursesRequestType.CACHE
+                    ) {
+                        detectUnfulfilledPurchase(enrolledCourses)
+                    }
                 }
             })
 
@@ -239,26 +249,18 @@ class MyCoursesListFragment : OfflineSupportBaseFragment(), RefreshListener {
     }
 
     /**
-     * Method to detect Unfulfilled Purchases if full screen loader is not visible.
+     * Method to detect Unfulfilled Purchases.
      *
      * @param enrolledCourses User enrolled courses.
      * */
     private fun detectUnfulfilledPurchase(enrolledCourses: List<EnrolledCoursesResponse>) {
-        val fullscreenLoader = FullscreenLoaderDialogFragment.getRetainedInstance(
-            fragmentManager = childFragmentManager
+        iapAnalytics.reset()
+        iapViewModel.detectUnfulfilledPurchase(
+            environment.loginPrefs.userId,
+            enrolledCourses,
+            IAPFlowData.IAPFlowType.SILENT,
+            Analytics.Screens.COURSE_ENROLLMENT
         )
-        if (fullscreenLoader != null) {
-            SnackbarErrorNotification(binding.root).showUpgradeSuccessSnackbar(R.string.purchase_success_message)
-            fullscreenLoader.closeLoader()
-        } else {
-            iapAnalytics.reset()
-            iapViewModel.detectUnfulfilledPurchase(
-                environment.loginPrefs.userId,
-                enrolledCourses,
-                IAPFlowData.IAPFlowType.SILENT,
-                Analytics.Screens.COURSE_ENROLLMENT
-            )
-        }
     }
 
     override fun onResume() {
@@ -298,7 +300,7 @@ class MyCoursesListFragment : OfflineSupportBaseFragment(), RefreshListener {
                 }
             }
             IAPFlowData.IAPAction.PURCHASE_FLOW_COMPLETE -> {
-                onRefresh()
+                courseViewModel.fetchEnrolledCourses(type = CoursesRequestType.LIVE)
             }
         }
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.kt
@@ -20,6 +20,7 @@ import org.edx.mobile.event.EnrolledInCourseEvent
 import org.edx.mobile.event.IAPFlowEvent
 import org.edx.mobile.event.MainDashboardRefreshEvent
 import org.edx.mobile.event.MoveToDiscoveryTabEvent
+import org.edx.mobile.event.MyCoursesRefreshEvent
 import org.edx.mobile.event.NetworkConnectivityChangeEvent
 import org.edx.mobile.exception.ErrorMessage
 import org.edx.mobile.extenstion.setVisibility
@@ -398,6 +399,12 @@ class MyCoursesListFragment : OfflineSupportBaseFragment(), RefreshListener {
     @Subscribe(sticky = true)
     @Suppress("UNUSED_PARAMETER")
     fun onEvent(event: MainDashboardRefreshEvent) {
+        courseViewModel.fetchEnrolledCourses(type = CoursesRequestType.LIVE)
+    }
+
+    @Subscribe(sticky = true)
+    @Suppress("UNUSED_PARAMETER")
+    fun onEvent(event: MyCoursesRefreshEvent) {
         courseViewModel.fetchEnrolledCourses(type = CoursesRequestType.LIVE)
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/SplashActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/SplashActivity.java
@@ -44,6 +44,7 @@ public class SplashActivity extends ComponentActivity {
         }
 
         final IEdxEnvironment environment = MainApplication.getEnvironment(this);
+        environment.getAppFeaturesPrefs().setAutoCheckUnfulfilledPurchase(true);
         if (environment.getLoginPrefs().isUserLoggedIn()) {
             environment.getRouter().showMainDashboard(SplashActivity.this);
         } else if (!environment.getConfig().isRegistrationEnabled()) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/FullscreenLoaderDialogFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/FullscreenLoaderDialogFragment.kt
@@ -79,7 +79,7 @@ class FullscreenLoaderDialogFragment : DialogFragment() {
         initObservers()
         if (iapFlowData?.isVerificationPending == true) {
             iapViewModel.executeOrder(iapFlowData)
-        } else if (iapFlowData?.flowType?.isSilentMode() == true) {
+        } else {
             purchaseFlowComplete()
         }
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/CourseViewModel.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/CourseViewModel.kt
@@ -37,6 +37,12 @@ class CourseViewModel @Inject constructor(
     private val _handleError = MutableLiveData<Throwable>()
     val handleError: LiveData<Throwable> = _handleError
 
+    var courseRequestType: CoursesRequestType
+
+    init {
+        courseRequestType = CoursesRequestType.NONE
+    }
+
     fun fetchEnrolledCourses(
         type: CoursesRequestType,
         showProgress: Boolean = true
@@ -52,6 +58,7 @@ class CourseViewModel @Inject constructor(
 
                 override fun onSuccess(result: Result.Success<EnrollmentResponse>) {
                     result.data?.let {
+                        courseRequestType = type
                         _enrolledCourses.postEvent(it.enrollments)
                         environment.appFeaturesPrefs.setAppConfig(it.appConfig)
 
@@ -98,9 +105,15 @@ class CourseViewModel @Inject constructor(
         }
     }
 
+    override fun onCleared() {
+        super.onCleared()
+        courseRequestType = CoursesRequestType.NONE
+    }
+
     sealed class CoursesRequestType {
         object LIVE : CoursesRequestType()
         object STALE : CoursesRequestType()
         object CACHE : CoursesRequestType()
+        object NONE : CoursesRequestType()
     }
 }


### PR DESCRIPTION
### Description

[LEARNER-9312](https://2u-internal.atlassian.net/browse/LEARNER-9312)
[LEARNER-9315](https://2u-internal.atlassian.net/browse/LEARNER-9315)

- Fix Error modal on My Courses after completing IAP flow from Course Dashboard.
- Check Unfulfilled Purchases only On live server calls for my courses and Once per app session.
- Fix the `Refresh Now` button action.
- Validate SKU `onPurchaseComplete` for billing processor.
- Fix Warning: Webview has been destroyed after an event is fired.
- Update the Refresh event to update my course list after in-app purchases.

ps: Issue LEARNER-9312 is not reproducible on the dev side, so the fix is scenario-based.