### PR TITLE
fix: Add action listener on RegisterActivity in case of API failure

### DIFF
--- a/OpenEdXMobile/res/layout/activity_register.xml
+++ b/OpenEdXMobile/res/layout/activity_register.xml
@@ -110,10 +110,9 @@
 
     </FrameLayout>
 
-    <TextView
-        android:id="@+id/content_unavailable_error_text"
-        style="@style/content_unavailable_error_text"
-        android:text="@string/reset_no_network_message"
+    <include
+        android:id="@+id/content_error"
+        layout="@layout/content_error"
         android:visibility="gone" />
 
     <include


### PR DESCRIPTION
### Description

[LEARNER-6670](https://2u-internal.atlassian.net/browse/LEARNER-6670)

- Add action listener in case of failure of response
- Add Update listener in case of out dated app version
- Include FullScreenErrorNotification 

<img src="https://user-images.githubusercontent.com/30689349/232171666-09845e44-6901-41f6-a435-3edae24286b4.png" height=480> <img src="https://user-images.githubusercontent.com/30689349/232171670-28baa497-742e-44f6-9c8c-a3743e8e9988.png" height=480>
