### PR TITLE
fix: Price not fetched in adjacent Course Component

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.kt
@@ -40,8 +40,8 @@ import javax.inject.Inject
 class CourseUnitMobileNotSupportedFragment : CourseUnitFragment() {
 
     private lateinit var binding: FragmentCourseUnitGradeBinding
-    private val iapViewModel: InAppPurchasesViewModel
-            by viewModels(ownerProducer = { requireActivity() })
+
+    private val iapViewModel: InAppPurchasesViewModel by viewModels()
 
     @Inject
     lateinit var iapAnalytics: InAppPurchasesAnalytics


### PR DESCRIPTION
### Description

[LEARNER-9351](https://2u-internal.atlassian.net/browse/LEARNER-9351)

The issue occurred due to the use of a shared view model at the component level, causing the first component to consume the price fetched for the second component, resulting in the continuous running of the shimmer.

Currently, the view model is shared between `CourseUnitNavigation` and `CourseUnitMobileNotSupported` without any information being shared from the fragment to the activity. The data flow is as follows:

1. Unsupported Fragment passes functional arguments for `IapFlowData` to `ViewModel_1`
2. `ViewModel_1` passes the relevant data from `IapFlowData` to `BillingProcessor`
3. `BillingProcessor` returns data to `ViewModel_1` and updates relevant `IapFlowData` fields
4. `IapFlowData` is transferred from `ViewModel_1` to Unsupported Fragment and then to `FullscreenLoader's` `ViewModel_2` via EventBus
5. `FullscreenLoader` completes the verification process using `ViewModel_2` `IapFlowData`, and transfers data back to `CourseUnitNavigation` via EventBus for course refresh

Since there is no communication between `CourseUnitNavigation` and `CourseUnitMobileNotSupported`, the view model's shareability can be removed. Analytics won't be an issue because they are constructed using Singleton design pattern.