### PR TITLE
build: Update app to Target API level 33 (Android 13)

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/observer/EventObserver.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/observer/EventObserver.kt
@@ -10,8 +10,9 @@ import androidx.lifecycle.Observer
  * Inspiration: https://gist.github.com/JoseAlcerreca/e0bba240d9b3cffa258777f12e5c0ae9
  */
 class EventObserver<T>(private val consumer: (T) -> Unit) : Observer<Event<T>> {
-    override fun onChanged(event: Event<T>?) {
-        consumer(event?.getContentIfNotConsumed() ?: return)
+
+    override fun onChanged(value: Event<T>) {
+        consumer(value.getContentIfNotConsumed() ?: return)
     }
 }
 

--- a/constants.gradle
+++ b/constants.gradle
@@ -1,11 +1,11 @@
 project.ext {
     APPLICATION_ID = "org.edx.mobile"
-    KOTLIN_VERSION = "1.6.10"
-    GRADLE_PLUGIN_VERSION = "7.0.3"
+    KOTLIN_VERSION = "1.8.0"
+    GRADLE_PLUGIN_VERSION = "7.0.4"
     BUILD_TOOLS_VERSION = "30.0.2"
-    COMPILE_SDK_VERSION = 31
+    COMPILE_SDK_VERSION = 33
     // API Level that the application will target
-    TARGET_SDK_VERSION = 31
+    TARGET_SDK_VERSION = 33
     // Minimum API Level required for the application to run
     MIN_SDK_VERSION = 21
 
@@ -13,12 +13,12 @@ project.ext {
     androidXVersion = '1.0.0'
     androidXAppCompactVersion = '1.2.0'
     kotlin_version_billing = "4.0.0"
-    hilt_version = "2.40.1"
+    hilt_version = "2.44"
     gms_google_services = "4.3.10"
 
     // Kotlin extensions library versions
-    androidXLifeCycle = '2.3.0'
-    androidXKotlinCore = '1.6.0'
-    androidXKotlinFramgnet = '1.3.0'
+    androidXLifeCycle = '2.6.1'
+    androidXKotlinCore = '1.10.0'
+    androidXKotlinFramgnet = '1.5.7'
     newrelic_version = '6.3.1'
 }


### PR DESCRIPTION


### Description

[LEARNER-9329](https://2u-internal.atlassian.net/browse/LEARNER-9329)

- Bump the `TARGET_SDK_VERSION` to API level `33` and other supporting libraries.
- Bump the `KOTLIN_VERSION` to `1.8.0`
- Bump the `GRADLE_PLUGIN_VERSION` to `7.0.4`
- Bump the `hilt_version` to `2.44`
- Bump the `androidXLifeCycle` to `2.6.1`
- Bump the `hilt_version` to `1.10.0`
- Code improvements after updating the `TARGET_SDK_VERSION`

ps: doesn’t change behavior from the repo consumer perspective.
