### PR TITLE
feat: Upgrade third-party libraries

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -8,25 +8,25 @@ buildscript {
     }
 
     dependencies {
-        classpath 'org.yaml:snakeyaml:1.29'
+        classpath "org.yaml:snakeyaml:2.0"
         //Screenshot testing library
-        classpath 'com.facebook.testing.screenshot:plugin:0.14.0'
+        classpath "com.facebook.testing.screenshot:plugin:0.14.0"
         classpath "com.google.gms:google-services:$gms_google_services"
     }
 }
 
-apply plugin: 'edxapp'
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-kapt' //To enable data binding with kotlin
-apply plugin: 'jacoco'
+apply plugin: "edxapp"
+apply plugin: "com.android.application"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-kapt" //To enable data binding with kotlin
+apply plugin: "jacoco"
 edx {
     platform = ANDROID
 }
 
-apply plugin: 'com.facebook.testing.screenshot'
-apply from: file('gradle_scripts/AndroidHelper.gradle')
-apply plugin: 'dagger.hilt.android.plugin'
+apply plugin: "com.facebook.testing.screenshot"
+apply from: file("gradle_scripts/AndroidHelper.gradle")
+apply plugin: "dagger.hilt.android.plugin"
 jacoco {
     toolVersion = "0.8.8"
 }
@@ -41,12 +41,12 @@ def getVersionName = { ->
     try {
         def branch = System.getenv("BRANCH")
         if (null == branch || branch.isEmpty()) {
-            def branchout = new ByteArrayOutputStream()
+            def branchOut = new ByteArrayOutputStream()
             exec {
-                commandLine 'git', 'rev-parse', '--abbrev-ref', 'HEAD'
-                standardOutput = branchout
+                commandLine "git", "rev-parse", "--abbrev-ref", "HEAD"
+                standardOutput = branchOut
             }
-            branch = branchout.toString().trim()
+            branch = branchOut.toString().trim()
         }
 
         def hasSemanticVersion = { s ->
@@ -58,7 +58,7 @@ def getVersionName = { ->
         } else {
             def stdout = new ByteArrayOutputStream()
             exec {
-                commandLine 'git', 'describe'
+                commandLine "git", "describe"
                 standardOutput = stdout
             }
             def describe = stdout.toString().trim()
@@ -79,7 +79,7 @@ def getVersionName = { ->
 def getVersionCode = { ->
     try {
         def versionName = getVersionName()
-        def semVer = versionName.split('\\.')
+        def semVer = versionName.split("\\.")
         def vCode
         vCode = semVer[0].toInteger() * 1000000 // Major version
         if (semVer.length > 1) {
@@ -96,19 +96,19 @@ def getVersionCode = { ->
 }
 
 task(version) doLast {
-    println String.format('%s (%s)', getVersionName(), getVersionCode())
+    println String.format("%s (%s)", getVersionName(), getVersionCode())
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: '*.jar')
+    implementation fileTree(dir: "libs", include: "*.jar")
 
-    // Webview crash fix after update the library
+    // WebView crash fix after update the library
     // Inspiration: https://github.com/PierfrancescoSoffritti/android-youtube-player/issues/461#issuecomment-696772172
     implementation "androidx.appcompat:appcompat:$androidXAppCompactVersion"
-    implementation "androidx.recyclerview:recyclerview:$androidXVersion"
-    implementation "androidx.cardview:cardview:$androidXVersion"
+    implementation "androidx.recyclerview:recyclerview:$androidXRecyclerViewVersion"
+    implementation "androidx.cardview:cardview:$androidXCardviewVersion"
     // For the optional Nullable annotation
-    implementation "androidx.annotation:annotation:$androidXVersion"
+    implementation "androidx.annotation:annotation:$androidXAnnotationVersion"
     // Kotlin Extensions
     implementation "androidx.core:core-ktx:$androidXKotlinCore"
     implementation "androidx.fragment:fragment-ktx:$androidXKotlinFramgnet"
@@ -118,144 +118,134 @@ dependencies {
 
     // NOTE: Always update the version of google-services and firebase libraries using the ones
     // provided in this link: https://developers.google.com/android/guides/releases
-    implementation "com.google.android.gms:play-services-plus:16.0.0"
-    implementation "com.google.android.gms:play-services-analytics:16.0.8"
-    implementation "com.google.android.gms:play-services-auth:16.0.1"
+    implementation "com.google.android.gms:play-services-plus:17.0.0"
+    implementation "com.google.android.gms:play-services-analytics:18.0.2"
+    implementation "com.google.android.gms:play-services-auth:20.5.0"
     // Google Firebase
-    implementation "com.google.firebase:firebase-core:16.0.9"
-    implementation "com.google.firebase:firebase-messaging:20.2.0"
+    implementation "com.google.firebase:firebase-core:21.1.1"
+    implementation "com.google.firebase:firebase-messaging:23.1.2"
 
     // Add the dependency for the Performance Monitoring library
-    implementation 'com.google.firebase:firebase-perf:17.0.2'
+    implementation "com.google.firebase:firebase-perf:20.3.2"
     // Firebase remote config
-    implementation 'com.google.firebase:firebase-config:16.5.0'
+    implementation "com.google.firebase:firebase-config:21.4.0"
 
     // Exo Player
-    implementation 'com.google.android.exoplayer:exoplayer:2.16.0'
+    implementation "com.google.android.exoplayer:exoplayer:2.18.7"
 
     // Youtube Player
-    implementation 'com.pierfrancescosoffritti.androidyoutubeplayer:core:12.0.0'
+    implementation "com.pierfrancescosoffritti.androidyoutubeplayer:core:12.0.0"
 
     // Google cast sdk
-    implementation "androidx.mediarouter:mediarouter:1.3.1"
-    implementation 'com.google.android.gms:play-services-cast-framework:21.2.0'
+    implementation "androidx.mediarouter:mediarouter:1.4.0"
+    implementation "com.google.android.gms:play-services-cast-framework:21.3.0"
 
-    implementation 'com.facebook.android:facebook-login:15.2.0'
-    implementation 'com.microsoft.identity.client:msal:4.2.0'
-    implementation 'commons-lang:commons-lang:2.6'
-    implementation 'com.google.code.gson:gson:2.9.0'
+    implementation "com.facebook.android:facebook-login:15.2.0"
+    implementation "com.microsoft.identity.client:msal:4.2.0"
+    implementation "commons-lang:commons-lang:2.6"
+    implementation "com.google.code.gson:gson:2.9.0"
     implementation "org.greenrobot:eventbus:3.3.1"
-    implementation 'com.squareup.phrase:phrase:1.1.0'
-    /*
-     * REASON FOR NOT UPGRADING Okhttp TO LATEST VERSION
-     * OkHttp works on Android 5.0+ (API level 21+) and on Java 8+.
-     * The OkHttp 3.12.x branch supports Android 2.3+ (API level 9+) and Java 7+. These platforms
-     * lack support for TLS 1.2 and should not be used. But because upgrading is difficult we will
-     * backport critical fixes to the 3.12.x branch through December 31, 2020.
-     * Ref: https://square.github.io/okhttp/#requirements
-     */
-    implementation 'com.squareup.okhttp3:okhttp:4.9.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:4.9.0'
+    implementation "com.squareup.phrase:phrase:1.1.0"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "com.squareup.okhttp3:logging-interceptor:4.11.0"
     /* Exclude dependencies defined statically at the top-
      * level, to prevent them from being resolved to the
      * latest version as a result of dynamic version
      * definitions in the transitive dependencies.
      */
-    implementation ('com.squareup.retrofit2:retrofit:2.9.0') {
-        exclude group: 'com.squareup.okhttp3', module: 'okhttp'
+    implementation("com.squareup.retrofit2:retrofit:2.9.0") {
+        exclude group: "com.squareup.okhttp3", module: "okhttp"
     }
-    implementation ('com.squareup.retrofit2:converter-gson:2.9.0') {
-        exclude group: 'com.squareup.okhttp3', module: 'okhttp'
-        exclude group: 'com.google.code.gson', module: 'gson'
+    implementation("com.squareup.retrofit2:converter-gson:2.9.0") {
+        exclude group: "com.squareup.okhttp3", module: "okhttp"
+        exclude group: "com.google.code.gson", module: "gson"
     }
-    implementation 'androidx.multidex:multidex:2.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'de.hdodenhof:circleimageview:2.0.0'
-    implementation 'com.github.bumptech.glide:glide:4.11.0'
-    implementation ('com.github.bumptech.glide:okhttp3-integration:4.11.0')
+    implementation "androidx.multidex:multidex:2.0.1"
+    implementation "androidx.constraintlayout:constraintlayout:2.1.4"
+    implementation "de.hdodenhof:circleimageview:2.0.0"
+    implementation "com.github.bumptech.glide:glide:4.11.0"
+    implementation "com.github.bumptech.glide:okhttp3-integration:4.11.0"
 
     // Segment Library
-    implementation 'com.segment.analytics.android:analytics:4.10.4'
+    implementation "com.segment.analytics.android:analytics:4.11.3"
     // Segment's Firebase integration
-    implementation 'com.segment.analytics.android.integrations:firebase:1.2.0'
+    implementation "com.segment.analytics.android.integrations:firebase:1.2.0"
     // Segment's GA integration
-    implementation('com.segment.analytics.android.integrations:google-analytics:1.0.0') {
-        exclude module: 'play-services-analytics'
+    implementation("com.segment.analytics.android.integrations:google-analytics:1.0.0") {
+        exclude module: "play-services-analytics"
         transitive = true
     }
 
     // Firebase Crashlytics SDK
-    implementation ('com.google.firebase:firebase-crashlytics:17.2.2'){
-        exclude group: 'javax.inject'
+    implementation("com.google.firebase:firebase-crashlytics:18.3.7") {
+        exclude group: "javax.inject"
         transitive = true
     }
 
     // Recommended: Add the Google Analytics SDK along Firebase Crashlytics SDK
-    implementation 'com.google.firebase:firebase-analytics:17.4.2'
+    implementation "com.google.firebase:firebase-analytics:21.3.0"
 
     // Branch SDK
     // Check this link for guide to updating Branch integration:
     // https://help.branch.io/developers-hub/docs/android-basic-integration
     implementation("io.branch.sdk.android:library:5.2.0") {
-        exclude module: 'answers-shim'
+        exclude module: "answers-shim"
     }
     implementation "com.google.android.gms:play-services-ads-identifier:18.0.1"
     implementation "com.android.installreferrer:installreferrer:2.2"
-    implementation "androidx.browser:browser:1.3.0"
+    implementation "androidx.browser:browser:1.5.0"
 
     // ViewPager2
-    implementation 'androidx.viewpager2:viewpager2:1.0.0'
+    implementation "androidx.viewpager2:viewpager2:1.0.0"
 
     // Material components like Chips and TabLayoutMediator
-    implementation 'com.google.android.material:material:1.5.0-alpha02'
+    implementation "com.google.android.material:material:1.9.0"
 
     // Braze SDK Integration
-    implementation 'com.appboy:appboy-segment-integration:14.0.0'
+    implementation "com.appboy:appboy-segment-integration:14.0.0"
 
     // test project configuration
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'androidx.test.ext:junit-ktx:1.1.1'
-    testImplementation 'androidx.test:core-ktx:1.2.0'
-    testImplementation 'androidx.arch.core:core-testing:2.1.0'
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "androidx.test.ext:junit-ktx:1.1.5"
+    testImplementation "androidx.test:core-ktx:1.5.0"
+    testImplementation "androidx.arch.core:core-testing:2.2.0"
     // To mock static classes
-    testImplementation 'org.mockito:mockito-inline:5.2.0'
-    testImplementation ("org.mockito:mockito-core:5.3.1"){
-        exclude group: 'org.hamcrest'
+    testImplementation "org.mockito:mockito-inline:5.2.0"
+    testImplementation("org.mockito:mockito-core:5.3.1") {
+        exclude group: "org.hamcrest"
     }
-    testImplementation "org.robolectric:robolectric:4.7.3"
-    testImplementation "com.github.nimbl3:robolectric.shadows-supportv4:4.1-SNAPSHOT"
-    testImplementation "org.robolectric:shadows-multidex:4.0.1"
-    testImplementation 'org.assertj:assertj-core:2.5.0'
+    testImplementation "org.robolectric:robolectric:4.10.3"
+    testImplementation "org.assertj:assertj-core:2.5.0"
     /**
      * AssertJ has been deprecated and doesn't support AndroidX classes.
      * Ref: https://github.com/square/assertj-android
      * Instead of AssertJ we should move towards Truth library that they recommend instead.
      * Ref: https://truth.dev/comparison.html
      */
-    testImplementation ('com.squareup.assertj:assertj-android:1.1.1') {
-        exclude group: 'com.android.support'
+    testImplementation("com.squareup.assertj:assertj-android:1.1.1") {
+        exclude group: "com.android.support"
     }
-    testImplementation ('com.squareup.assertj:assertj-android-support-v4:1.1.1') {
-        exclude group: 'com.android.support'
+    testImplementation("com.squareup.assertj:assertj-android-support-v4:1.1.1") {
+        exclude group: "com.android.support"
     }
-    testImplementation ('com.squareup.assertj:assertj-android-appcompat-v7:1.1.1') {
-        exclude group: 'com.android.support'
+    testImplementation("com.squareup.assertj:assertj-android-appcompat-v7:1.1.1") {
+        exclude group: "com.android.support"
     }
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
-    testImplementation ('com.squareup.retrofit2:retrofit-mock:2.9.0') {
-        exclude group: 'com.squareup.okhttp3', module: 'okhttp'
+    testImplementation "com.squareup.okhttp3:mockwebserver:4.11.0"
+    testImplementation("com.squareup.retrofit2:retrofit-mock:2.9.0") {
+        exclude group: "com.squareup.okhttp3", module: "okhttp"
     }
 
-    androidTestImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.12.1'
-    androidTestImplementation ('org.mockito:mockito-core:2.8.9'){
-        exclude group: 'org.hamcrest'
+    androidTestImplementation "junit:junit:4.13.2"
+    androidTestImplementation "androidx.test.ext:junit:1.1.5"
+    androidTestImplementation "androidx.test:rules:1.5.0"
+    androidTestImplementation "org.hamcrest:hamcrest-library:1.3"
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.5.1"
+    androidTestImplementation "com.linkedin.dexmaker:dexmaker-mockito:2.12.1"
+    androidTestImplementation("org.mockito:mockito-core:5.3.1") {
+        exclude group: "org.hamcrest"
     }
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${KOTLIN_VERSION}"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION"
     implementation "com.android.billingclient:billing-ktx:$kotlin_version_billing"
 
     // dependency on Shimmer for Android
@@ -268,7 +258,7 @@ dependencies {
      * Following link explains setting up LeakCanary for different product flavors:
      * https://square.github.io/leakcanary/recipes/#setting-up-leakcanary-for-different-product-flavors
      */
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.7'
+    debugImplementation "com.squareup.leakcanary:leakcanary-android:2.7"
 
     // Hilt build dependencies
     implementation "com.google.dagger:hilt-android:$hilt_version"
@@ -282,15 +272,15 @@ dependencies {
 }
 
 configurations {
-    androidTestImplementation.exclude group: 'javax.inject'
-    androidTestImplementation.exclude group: 'javax.annotation'
+    androidTestImplementation.exclude group: "javax.inject"
+    androidTestImplementation.exclude group: "javax.annotation"
 }
 
 def config = new TaskHelper().loadConfig(project)
-def firebaseConfig = config.get('FIREBASE')
-def firebaseEnabled = firebaseConfig?.get('ENABLED')
+def firebaseConfig = config.get("FIREBASE")
+def firebaseEnabled = firebaseConfig?.get("ENABLED")
 if (firebaseEnabled ?: false) {
-    apply plugin: 'com.google.gms.google-services'
+    apply plugin: "com.google.gms.google-services"
     /*
      * Getting some libraries conflict after adding the microsoft client library for microsoft SSO
      * another at an exact version (e.g. [1.3.1 ,2.3]).", so adding the following statement to
@@ -301,12 +291,12 @@ if (firebaseEnabled ?: false) {
         disableVersionCheck = true
     }
     // Apply the Performance Monitoring plugin to enable instrumentation
-    apply plugin: 'com.google.firebase.firebase-perf'
+    apply plugin: "com.google.firebase.firebase-perf"
     // Firebase Crashlytics plugin.
-    apply plugin: 'com.google.firebase.crashlytics'
+    apply plugin: "com.google.firebase.crashlytics"
 }
 // Variable to check if Firebase Cloud Messaging is enabled
-def fcmEnabled = config.get('PUSH_NOTIFICATIONS') && firebaseEnabled && firebaseConfig?.get('CLOUD_MESSAGING_ENABLED')
+def fcmEnabled = config.get("PUSH_NOTIFICATIONS") && firebaseEnabled && firebaseConfig?.get("CLOUD_MESSAGING_ENABLED")
 
 // Variable to check if Microsoft is enabled
 def microsoftConfig = config.get("MICROSOFT")
@@ -345,12 +335,12 @@ android {
         vectorDrawables.useSupportLibrary = true
 
         // test configuration
-        testApplicationId 'org.edx.mobile.test'
+        testApplicationId "org.edx.mobile.test"
 
         for (task in project.gradle.startParameter.taskNames) {
             if (task.contains("ScreenshotTest")) {
-                Map<String, String> map = new HashMap<String, String>();
-                map.put("package", "org.edx.mobile.test.screenshot");
+                Map<String, String> map = new HashMap<String, String>()
+                map.put("package", "org.edx.mobile.test.screenshot")
                 setTestInstrumentationRunnerArguments map
             }
         }
@@ -364,36 +354,36 @@ android {
         // Enabling multidex support.
         multiDexEnabled true
 
-        def platformName = config.get('PLATFORM_NAME')
+        def platformName = config.get("PLATFORM_NAME")
         resValue "string", "platform_name", platformName
 
-        def appShortcutName = config.get('APP_SHORTCUT_NAME')
+        def appShortcutName = config.get("APP_SHORTCUT_NAME")
         if (appShortcutName == null) {
             appShortcutName = platformName
         }
         resValue "string", "shortcut_name", appShortcutName
 
-        def phoneticPlatformName = config.get('PHONETIC_PLATFORM_NAME')
+        def phoneticPlatformName = config.get("PHONETIC_PLATFORM_NAME")
         if (phoneticPlatformName == null) {
             phoneticPlatformName = platformName
         }
         resValue "string", "phonetic_platform_name", phoneticPlatformName
 
         def branchKey = ""
-        def branch = config.get('BRANCH')
-        if (branch != null && branch.get('ENABLED')) {
-            branchKey = branch.get('KEY')
+        def branch = config.get("BRANCH")
+        if (branch != null && branch.get("ENABLED")) {
+            branchKey = branch.get("KEY")
             if (null == branchKey) {
                 throw new GradleException("You must set BRANCH_KEY if Branch is enabled")
             }
         }
 
         def fbLoginProtocolScheme = ""
-        def facebook = config.get('FACEBOOK')
+        def facebook = config.get("FACEBOOK")
         def fbClientToken = ""
-        if (facebook?.get('ENABLED')) {
-            def facebookAppId = facebook.get('FACEBOOK_APP_ID')
-            fbClientToken = facebook.get('CLIENT_TOKEN')
+        if (facebook?.get("ENABLED")) {
+            def facebookAppId = facebook.get("FACEBOOK_APP_ID")
+            fbClientToken = facebook.get("CLIENT_TOKEN")
             if (null == facebookAppId || null == fbClientToken) {
                 throw new GradleException("You must set FACEBOOK_APP_ID and CLIENT_TOKEN if FACEBOOK is enabled")
             }
@@ -407,19 +397,19 @@ android {
                                 microsoftSignature   : microsoftSignature,
                                 fbClientToken        : fbClientToken,
                                 fbLoginProtocolScheme: fbLoginProtocolScheme,
-                                sdCardEnabled        : config.get('DOWNLOAD_TO_SD_CARD_ENABLED') ?: true]
+                                sdCardEnabled        : config.get("DOWNLOAD_TO_SD_CARD_ENABLED") ?: true]
 
         testOptions.unitTests.includeAndroidResources = true
     }
     sourceSets {
         main {
-            manifest.srcFile 'AndroidManifest.xml'
-            java.srcDirs = ['src/main/java']
-            resources.srcDirs = ['src/main/java']
-            aidl.srcDirs = ['src/main/java']
-            renderscript.srcDirs = ['src/main/java']
-            res.srcDirs = ['res']
-            assets.srcDirs = ['assets']
+            manifest.srcFile "AndroidManifest.xml"
+            java.srcDirs = ["src/main/java"]
+            resources.srcDirs = ["src/main/java"]
+            aidl.srcDirs = ["src/main/java"]
+            renderscript.srcDirs = ["src/main/java"]
+            res.srcDirs = ["res"]
+            assets.srcDirs = ["assets"]
         }
 
         // Move the build types to build-types/<type>
@@ -428,18 +418,18 @@ android {
         // conflict with src/ being used by the main source set.
         // Adding new build types or product flavors should be accompanied
         // by a similar customization.
-        debug.setRoot('build-types/debug')
-        release.setRoot('build-types/release')
+        debug.setRoot("build-types/debug")
+        release.setRoot("build-types/release")
 
-        if (project.hasProperty('RES_DIR')) {
+        if (project.hasProperty("RES_DIR")) {
             prod.res.srcDirs = [RES_DIR]
         }
 
-        if (project.hasProperty('ASSETS')) {
+        if (project.hasProperty("ASSETS")) {
             prod.assets.srcDirs = [ASSETS]
         }
         // Shared directory of both unit and instrumentation to use common base classes.
-        String sharedTestDir = 'src/sharedTest/java'
+        String sharedTestDir = "src/sharedTest/java"
         test {
             java.srcDirs += sharedTestDir
         }
@@ -451,7 +441,7 @@ android {
 
     productFlavors {
         prod {
-            if (project.hasProperty('APPLICATION_ID')) {
+            if (project.hasProperty("APPLICATION_ID")) {
                 applicationId APPLICATION_ID
             }
         }
@@ -460,11 +450,13 @@ android {
     buildTypes {
         debug {
             testCoverageEnabled true
-            pseudoLocalesEnabled true // Set device language to "en_XA" to test glyphs, or "ar_XB" to test RTL support
+            // Set device language to "en_XA" to test glyphs, or "ar_XB" to test RTL support
+            pseudoLocalesEnabled true
         }
         debuggable.initWith(buildTypes.debug)
         debuggable {
-            testCoverageEnabled = false // Set to "false" to work around debugger issue: https://code.google.com/p/android/issues/detail?id=123771
+            // Set to "false" to work around debugger issue: https://code.google.com/p/android/issues/detail?id=123771
+            testCoverageEnabled = false
             matchingFallbacks = ["debug"]
         }
 
@@ -476,29 +468,29 @@ android {
                     mappingFileUploadEnabled true
                 }
             }
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
             // Only apply release signing configurations if keystore.properties is available
-            if (project.file('signing/keystore.properties').exists()) {
-                apply from: 'signing/signing.gradle'
+            if (project.file("signing/keystore.properties").exists()) {
+                apply from: "signing/signing.gradle"
             }
             applicationVariants.all { variant ->
                 variant.outputs.all { output ->
-                    project.ext { appName = 'edx' }
-                    outputFileName  = "${project.ext.appName}-${variant.buildType.name}-${versionName}.apk"
+                    project.ext { appName = "edx" }
+                    outputFileName = "${project.ext.appName}-${variant.buildType.name}-${versionName}.apk"
                 }
             }
         }
     }
     packagingOptions {
         resources {
-            excludes += ['LICENSE.txt', 'APK LICENSE.txt', 'META-INF/DEPENDENCIES', 'META-INF/LICENSE', 'META-INF/NOTICE', 'META-INF/LICENSE.txt', 'META-INF/NOTICE.txt']
+            excludes += ["LICENSE.txt", "APK LICENSE.txt", "META-INF/DEPENDENCIES", "META-INF/LICENSE", "META-INF/NOTICE", "META-INF/LICENSE.txt", "META-INF/NOTICE.txt"]
         }
     }
 
     testOptions {
-         unitTests.all {
-             maxHeapSize '1g'
-         }
+        unitTests.all {
+            maxHeapSize "1g"
+        }
     }
 
     compileOptions {
@@ -509,17 +501,17 @@ android {
     kotlinOptions {
         /**
          * Braze may cause a compiler warning about "Inheritance from an interface with
-         * '@JvmDefault' members" without this flag.
+         * "@JvmDefault" members" without this flag.
          * Ref: https://github.com/Appboy/appboy-android-sdk/blob/master/CHANGELOG.md#important-2
          */
-        freeCompilerArgs = ['-Xjvm-default=all']
+        freeCompilerArgs = ["-Xjvm-default=all"]
         jvmTarget = "17"
     }
     lint {
         abortOnError true
-        error 'StopShip', 'ContentDescription'
+        error "StopShip", "ContentDescription"
         showAll true
-        warning 'TypographyQuotes', 'InvalidPackage', 'MissingTranslation', 'ImpliedQuantity'
+        warning "TypographyQuotes", "InvalidPackage", "MissingTranslation", "ImpliedQuantity"
     }
 }
 
@@ -572,7 +564,7 @@ android.applicationVariants.all { variant ->
     }
 }
 
-task jacocoProdDebugUnitTestReport(type: JacocoReport, dependsOn: ['testProdDebugUnitTest']) {
+task jacocoProdDebugUnitTestReport(type: JacocoReport, dependsOn: ["testProdDebugUnitTest"]) {
     reports {
         xml.required = true
         html.required = true

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/NonNullObserver.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/NonNullObserver.kt
@@ -3,7 +3,7 @@ package org.edx.mobile.util
 import androidx.lifecycle.Observer
 
 class NonNullObserver<T>(private val consumer: (content: T) -> Unit) : Observer<T?> {
-    override fun onChanged(t: T?) {
-        consumer(t ?: return)
+    override fun onChanged(value: T?) {
+        consumer(value ?: return)
     }
 }

--- a/OpenEdXMobile/src/test/java/org/edx/mobile/viewModel/LiveDataTestUtil.kt
+++ b/OpenEdXMobile/src/test/java/org/edx/mobile/viewModel/LiveDataTestUtil.kt
@@ -17,15 +17,15 @@ import java.util.concurrent.TimeoutException
  */
 @VisibleForTesting(otherwise = VisibleForTesting.NONE)
 fun <T> LiveData<T>.getOrAwaitValue(
-        time: Long = 2,
-        timeUnit: TimeUnit = TimeUnit.SECONDS,
-        afterObserve: () -> Unit = {}
+    time: Long = 2,
+    timeUnit: TimeUnit = TimeUnit.SECONDS,
+    afterObserve: () -> Unit = {}
 ): T {
     var data: T? = null
     val latch = CountDownLatch(1)
     val observer = object : Observer<T> {
-        override fun onChanged(o: T) {
-            data = o
+        override fun onChanged(value: T) {
+            data = value
             latch.countDown()
             this@getOrAwaitValue.removeObserver(this)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,11 @@ allprojects {
         // The order in which you list these repositories matter.
         google()
         mavenCentral()
-        maven { url 'https://maven.google.com' }
-        maven { url 'https://jitpack.io' }
+        maven { url "https://maven.google.com" }
+        maven { url "https://jitpack.io" }
         maven { url "https://appboy.github.io/appboy-android-sdk/sdk" }
         maven { url "https://appboy.github.io/appboy-segment-android/sdk" }
-        maven { url 'https://pkgs.dev.azure.com/MicrosoftDeviceSDK/DuoSDK-Public/_packaging/Duo-SDK-Feed/maven/v1' }
+        maven { url "https://pkgs.dev.azure.com/MicrosoftDeviceSDK/DuoSDK-Public/_packaging/Duo-SDK-Feed/maven/v1" }
     }
     project.apply from: "${rootDir}/constants.gradle"
 }
@@ -25,56 +25,56 @@ buildscript {
         classpath "com.android.tools.build:gradle:$GRADLE_PLUGIN_VERSION"
         classpath "com.google.gms:google-services:$gms_google_services"
         // Add the dependency for the Performance Monitoring plugin
-        classpath 'com.google.firebase:perf-plugin:1.4.1'  // Performance Monitoring plugin
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${KOTLIN_VERSION}"
+        classpath "com.google.firebase:perf-plugin:1.4.2"  // Performance Monitoring plugin
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
         // Firebase Crashlytics Gradle plugin.
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.5.2'
-        classpath "com.google.dagger:hilt-android-gradle-plugin:${hilt_version}"
+        classpath "com.google.firebase:firebase-crashlytics-gradle:2.9.5"
+        classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
         classpath "org.jacoco:org.jacoco.core:0.8.8"
     }
 }
 
-// task that creates 'artifacts' directory
+// task that creates "artifacts" directory
 task createBuildArtifactsDirectory { task ->
     doLast {
         def hashPipe = new ByteArrayOutputStream()
         task.project.exec {
-            commandLine = ['git', 'rev-parse', '--verify', 'HEAD']
+            commandLine = ["git", "rev-parse", "--verify", "HEAD"]
             standardOutput = hashPipe
         }
 
         def destDir = "artifacts"
         task.project.exec {
-            commandLine = ['mkdir', '-p', destDir]
+            commandLine = ["mkdir", "-p", destDir]
         }
     }
 }
 
-// Copies unit test reports to the 'artifacts' directory
+// Copies unit test reports to the "artifacts" directory
 task copyUnitTestBuildArtifacts { task ->
     doLast {
         // copy unit test reports
         def srcPath = "OpenEdXMobile/build/reports"
         task.project.exec {
-            commandLine = ['cp', '-R', srcPath, 'artifacts']
+            commandLine = ["cp", "-R", srcPath, "artifacts"]
         }
     }
 }
 copyUnitTestBuildArtifacts.dependsOn createBuildArtifactsDirectory
 
-// Copies lint report to the 'artifacts' directory
+// Copies lint report to the "artifacts" directory
 task copyLintBuildArtifacts(type: Copy) {
-    from 'OpenEdXMobile/build/outputs'
-    into 'artifacts'
-    include 'lint-results*'
-    include 'lint-results*/**'
+    from "OpenEdXMobile/build/outputs"
+    into "artifacts"
+    include "lint-results*"
+    include "lint-results*/**"
 }
 copyLintBuildArtifacts.dependsOn createBuildArtifactsDirectory
 
 // Disables preDex which reduces the amount of memory required to build an APK. This is important
 // for CI where there is a memory limit. PreDex is also not useful in CI where a new build is
 // desired on every run.
-project.ext.preDexLibs = !project.hasProperty('disablePreDex')
+project.ext.preDexLibs = !project.hasProperty("disablePreDex")
 
 // Increases adb timeout for installing an apk. This tweak is need for slow adb installs on an
 // emulator for CI.

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -24,7 +24,7 @@ subprojects {
         // we should figure this out
         implementation "org.codehaus.groovy:groovy-all:3.0.13"
         implementation gradleApi()
-        implementation "org.yaml:snakeyaml:1.29"
+        implementation "org.yaml:snakeyaml:2.0"
     }
 }
 

--- a/constants.gradle
+++ b/constants.gradle
@@ -1,6 +1,6 @@
 project.ext {
     APPLICATION_ID = "org.edx.mobile"
-    KOTLIN_VERSION = "1.8.10"
+    KOTLIN_VERSION = "1.8.22"
     GRADLE_PLUGIN_VERSION = "8.0.2"
     COMPILE_SDK_VERSION = 33
     // API Level that the application will target
@@ -9,14 +9,16 @@ project.ext {
     MIN_SDK_VERSION = 21
 
     // App dependencies
-    androidXVersion = '1.0.0'
-    androidXAppCompactVersion = '1.2.0'
+    androidXRecyclerViewVersion = "1.3.0"
+    androidXCardviewVersion = "1.0.0"
+    androidXAnnotationVersion = "1.6.0"
+    androidXAppCompactVersion = "1.6.1"
     kotlin_version_billing = "4.0.0"
     hilt_version = "2.44"
-    gms_google_services = "4.3.10"
+    gms_google_services = "4.3.15"
 
     // Kotlin extensions library versions
-    androidXLifeCycle = '2.6.1'
-    androidXKotlinCore = '1.10.0'
-    androidXKotlinFramgnet = '1.5.7'
+    androidXLifeCycle = "2.6.1"
+    androidXKotlinCore = "1.10.1"
+    androidXKotlinFramgnet = "1.6.0"
 }


### PR DESCRIPTION
### Description

[LEARNER-8555](https://2u-internal.atlassian.net/browse/LEARNER-8555)

Bump the 3rd party libraries to the latest stable version(till date), in support to migrate to Android 13.

### Testing
- The app shouldn't crash at any point.
- UI/UX shouldn't be changed.

### Note:
The following will cover as part of different tickets.
- `com.android.billingclient:billing-ktx`
- SDK 33 introduces some warning, that requires major code changes and testing. `getSerializable`, `getParcelable`, `get(String!): Any?` e.t.c methods are deprecated.