### PR TITLE
fix: The loading indicator is not aligned properly in webviews

### DIFF
--- a/OpenEdXMobile/res/layout/authenticated_webview.xml
+++ b/OpenEdXMobile/res/layout/authenticated_webview.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <FrameLayout
         android:id="@+id/content_error_root"
@@ -7,11 +8,17 @@
         android:layout_height="match_parent"
         android:background="@color/white">
 
-        <org.edx.mobile.view.custom.EdxAssessmentWebView
-            android:id="@+id/webview"
+        <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="@color/white" />
+            app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+            <org.edx.mobile.view.custom.EdxAssessmentWebView
+                android:id="@+id/webview"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/white" />
+        </androidx.core.widget.NestedScrollView>
 
         <include
             android:id="@+id/loading_indicator"

--- a/OpenEdXMobile/res/layout/fragment_authenticated_webview.xml
+++ b/OpenEdXMobile/res/layout/fragment_authenticated_webview.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
@@ -19,19 +18,12 @@
                 android:visibility="gone"
                 tools:visibility="visible" />
 
-            <androidx.core.widget.NestedScrollView
+            <org.edx.mobile.view.custom.AuthenticatedWebView
+                android:id="@+id/auth_webview"
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
                 android:layout_weight="1"
-                app:layout_behavior="@string/appbar_scrolling_view_behavior">
-
-                <org.edx.mobile.view.custom.AuthenticatedWebView
-                    android:id="@+id/auth_webview"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:background="@color/white" />
-
-            </androidx.core.widget.NestedScrollView>
+                android:background="@color/white" />
 
             <TextView
                 android:id="@+id/tv_open_browser"


### PR DESCRIPTION
### Description

[LEARNER-9338](https://2u-internal.atlassian.net/browse/LEARNER-9338)

- Fix the loading indicator that is not aligned properly in web views.
- Encapsulate the `AuthenticatedWebView` with the `NestedScrollView` instated of `EdxAssessmentWebView`.