### PR TITLE
chore: add price & currency_code in Execute API's request body

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/BillingProcessor.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/BillingProcessor.kt
@@ -223,5 +223,5 @@ class BillingProcessor @Inject constructor(@ApplicationContext val context: Cont
     }
 }
 
-fun SkuDetails.getPriceAmount(): Float =
-    this.priceAmountMicros.toFloat() / BillingProcessor.MICROS_TO_UNIT
+fun SkuDetails.getPriceAmount(): Double =
+    this.priceAmountMicros.toDouble() / BillingProcessor.MICROS_TO_UNIT

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/BillingProcessor.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/BillingProcessor.kt
@@ -209,6 +209,7 @@ class BillingProcessor @Inject constructor(@ApplicationContext val context: Cont
         private val TAG = BillingProcessor::class.java.simpleName
         private const val RECONNECT_TIMER_START_MILLISECONDS = 1L * 1000L
         private const val RECONNECT_MAX_COUNT = 3 // retry connection max count
+        const val MICROS_TO_UNIT = 1_000_000 // 1,000,000 micro-units equal one unit of the currency.
     }
 
     interface BillingFlowListeners {
@@ -221,3 +222,5 @@ class BillingProcessor @Inject constructor(@ApplicationContext val context: Cont
         fun onPurchaseComplete(purchase: Purchase) {}
     }
 }
+
+fun SkuDetails.getPriceAmount(): Long = this.priceAmountMicros / BillingProcessor.MICROS_TO_UNIT

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/BillingProcessor.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/BillingProcessor.kt
@@ -209,7 +209,7 @@ class BillingProcessor @Inject constructor(@ApplicationContext val context: Cont
         private val TAG = BillingProcessor::class.java.simpleName
         private const val RECONNECT_TIMER_START_MILLISECONDS = 1L * 1000L
         private const val RECONNECT_MAX_COUNT = 3 // retry connection max count
-        const val MICROS_TO_UNIT = 1_000_000 // 1,000,000 micro-units equal one unit of the currency.
+        const val MICROS_TO_UNIT = 1_000_000 // 1,000,000 micro-units equal one unit of the currency
     }
 
     interface BillingFlowListeners {
@@ -223,4 +223,5 @@ class BillingProcessor @Inject constructor(@ApplicationContext val context: Cont
     }
 }
 
-fun SkuDetails.getPriceAmount(): Long = this.priceAmountMicros / BillingProcessor.MICROS_TO_UNIT
+fun SkuDetails.getPriceAmount(): Float =
+    this.priceAmountMicros.toFloat() / BillingProcessor.MICROS_TO_UNIT

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/InAppPurchasesAPI.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/InAppPurchasesAPI.kt
@@ -26,7 +26,7 @@ class InAppPurchasesAPI @Inject constructor(private val iapService: InAppPurchas
         basketId: Long,
         productId: String,
         purchaseToken: String,
-        price: Long?,
+        priceAmount: Float?,
         currencyCode: String?,
     ): Call<ExecuteOrderResponse> {
         return iapService.executeOrder(
@@ -34,7 +34,7 @@ class InAppPurchasesAPI @Inject constructor(private val iapService: InAppPurchas
             productId = productId,
             paymentProcessor = ApiConstants.PAYMENT_PROCESSOR,
             purchaseToken = purchaseToken,
-            price = price,
+            priceAmount = priceAmount,
             currencyCode = currencyCode,
         )
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/InAppPurchasesAPI.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/InAppPurchasesAPI.kt
@@ -25,13 +25,17 @@ class InAppPurchasesAPI @Inject constructor(private val iapService: InAppPurchas
     fun executeOrder(
         basketId: Long,
         productId: String,
-        purchaseToken: String
+        purchaseToken: String,
+        price: Long?,
+        currencyCode: String?,
     ): Call<ExecuteOrderResponse> {
         return iapService.executeOrder(
             basketId = basketId,
             productId = productId,
             paymentProcessor = ApiConstants.PAYMENT_PROCESSOR,
-            purchaseToken = purchaseToken
+            purchaseToken = purchaseToken,
+            price = price,
+            currencyCode = currencyCode,
         )
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/InAppPurchasesAPI.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/InAppPurchasesAPI.kt
@@ -26,7 +26,7 @@ class InAppPurchasesAPI @Inject constructor(private val iapService: InAppPurchas
         basketId: Long,
         productId: String,
         purchaseToken: String,
-        priceAmount: Float?,
+        priceAmount: Double?,
         currencyCode: String?,
     ): Call<ExecuteOrderResponse> {
         return iapService.executeOrder(

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/InAppPurchasesAPI.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/InAppPurchasesAPI.kt
@@ -26,15 +26,15 @@ class InAppPurchasesAPI @Inject constructor(private val iapService: InAppPurchas
         basketId: Long,
         productId: String,
         purchaseToken: String,
-        priceAmount: Double?,
-        currencyCode: String?,
+        price: Double,
+        currencyCode: String,
     ): Call<ExecuteOrderResponse> {
         return iapService.executeOrder(
             basketId = basketId,
             productId = productId,
             paymentProcessor = ApiConstants.PAYMENT_PROCESSOR,
             purchaseToken = purchaseToken,
-            priceAmount = priceAmount,
+            price = price,
             currencyCode = currencyCode,
         )
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/InAppPurchasesService.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/InAppPurchasesService.kt
@@ -46,7 +46,7 @@ interface InAppPurchasesService {
         @Field("productId") productId: String,
         @Field("payment_processor") paymentProcessor: String,
         @Field("purchaseToken") purchaseToken: String,
-        @Field("price") price: Long?,
-        @Field("currency_code") currencyCode: String?
+        @Field("price_amount") priceAmount: Float?,
+        @Field("currency_code") currencyCode: String?,
     ): Call<ExecuteOrderResponse>
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/InAppPurchasesService.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/InAppPurchasesService.kt
@@ -46,7 +46,7 @@ interface InAppPurchasesService {
         @Field("productId") productId: String,
         @Field("payment_processor") paymentProcessor: String,
         @Field("purchaseToken") purchaseToken: String,
-        @Field("price_amount") priceAmount: Double?,
-        @Field("currency_code") currencyCode: String?,
+        @Field("price") price: Double,
+        @Field("currency_code") currencyCode: String,
     ): Call<ExecuteOrderResponse>
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/InAppPurchasesService.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/InAppPurchasesService.kt
@@ -45,6 +45,8 @@ interface InAppPurchasesService {
         @Field("basket_id") basketId: Long,
         @Field("productId") productId: String,
         @Field("payment_processor") paymentProcessor: String,
-        @Field("purchaseToken") purchaseToken: String
+        @Field("purchaseToken") purchaseToken: String,
+        @Field("price") price: Long?,
+        @Field("currency_code") currencyCode: String?
     ): Call<ExecuteOrderResponse>
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/InAppPurchasesService.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/InAppPurchasesService.kt
@@ -46,7 +46,7 @@ interface InAppPurchasesService {
         @Field("productId") productId: String,
         @Field("payment_processor") paymentProcessor: String,
         @Field("purchaseToken") purchaseToken: String,
-        @Field("price_amount") priceAmount: Float?,
+        @Field("price_amount") priceAmount: Double?,
         @Field("currency_code") currencyCode: String?,
     ): Call<ExecuteOrderResponse>
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/iap/IAPFlowData.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/iap/IAPFlowData.kt
@@ -9,8 +9,8 @@ data class IAPFlowData(
     var productId: String = "",
     var basketId: Long = 0,
     var purchaseToken: String = "",
-    var priceAmount: Double? = null,
-    var currencyCode: String? = null,
+    var price: Double = 0.0,
+    var currencyCode: String = "",
     var screenName: String = "",
     var isVerificationPending: Boolean = false
 ) : Serializable {
@@ -19,8 +19,8 @@ data class IAPFlowData(
         isCourseSelfPaced = false
         productId = ""
         basketId = 0
-        priceAmount = null
-        currencyCode = null
+        price = 0.0
+        currencyCode = ""
         purchaseToken = ""
         isVerificationPending = false
         screenName = ""

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/iap/IAPFlowData.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/iap/IAPFlowData.kt
@@ -9,6 +9,8 @@ data class IAPFlowData(
     var productId: String = "",
     var basketId: Long = 0,
     var purchaseToken: String = "",
+    var price: Long? = null,
+    var currencyCode: String? = null,
     var screenName: String = "",
     var isVerificationPending: Boolean = false
 ) : Serializable {
@@ -17,6 +19,8 @@ data class IAPFlowData(
         isCourseSelfPaced = false
         productId = ""
         basketId = 0
+        price = null
+        currencyCode = null
         purchaseToken = ""
         isVerificationPending = false
         screenName = ""

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/iap/IAPFlowData.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/iap/IAPFlowData.kt
@@ -9,7 +9,7 @@ data class IAPFlowData(
     var productId: String = "",
     var basketId: Long = 0,
     var purchaseToken: String = "",
-    var priceAmount: Float? = null,
+    var priceAmount: Double? = null,
     var currencyCode: String? = null,
     var screenName: String = "",
     var isVerificationPending: Boolean = false

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/iap/IAPFlowData.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/iap/IAPFlowData.kt
@@ -9,7 +9,7 @@ data class IAPFlowData(
     var productId: String = "",
     var basketId: Long = 0,
     var purchaseToken: String = "",
-    var price: Long? = null,
+    var priceAmount: Float? = null,
     var currencyCode: String? = null,
     var screenName: String = "",
     var isVerificationPending: Boolean = false
@@ -19,7 +19,7 @@ data class IAPFlowData(
         isCourseSelfPaced = false
         productId = ""
         basketId = 0
-        price = null
+        priceAmount = null
         currencyCode = null
         purchaseToken = ""
         isVerificationPending = false

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/repository/InAppPurchasesRepository.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/repository/InAppPurchasesRepository.kt
@@ -47,7 +47,7 @@ class InAppPurchasesRepository(private var iapAPI: InAppPurchasesAPI) {
         basketId: Long,
         productId: String,
         purchaseToken: String,
-        priceAmount: Float?,
+        priceAmount: Double?,
         currencyCode: String?,
         callback: NetworkResponseCallback<ExecuteOrderResponse>
     ) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/repository/InAppPurchasesRepository.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/repository/InAppPurchasesRepository.kt
@@ -47,7 +47,7 @@ class InAppPurchasesRepository(private var iapAPI: InAppPurchasesAPI) {
         basketId: Long,
         productId: String,
         purchaseToken: String,
-        price: Long?,
+        priceAmount: Float?,
         currencyCode: String?,
         callback: NetworkResponseCallback<ExecuteOrderResponse>
     ) {
@@ -55,7 +55,7 @@ class InAppPurchasesRepository(private var iapAPI: InAppPurchasesAPI) {
             basketId = basketId,
             productId = productId,
             purchaseToken = purchaseToken,
-            price = price,
+            priceAmount = priceAmount,
             currencyCode = currencyCode,
         ).enqueue(object : Callback<ExecuteOrderResponse> {
             override fun onResponse(

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/repository/InAppPurchasesRepository.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/repository/InAppPurchasesRepository.kt
@@ -47,15 +47,15 @@ class InAppPurchasesRepository(private var iapAPI: InAppPurchasesAPI) {
         basketId: Long,
         productId: String,
         purchaseToken: String,
-        priceAmount: Double?,
-        currencyCode: String?,
+        price: Double,
+        currencyCode: String,
         callback: NetworkResponseCallback<ExecuteOrderResponse>
     ) {
         iapAPI.executeOrder(
             basketId = basketId,
             productId = productId,
             purchaseToken = purchaseToken,
-            priceAmount = priceAmount,
+            price = price,
             currencyCode = currencyCode,
         ).enqueue(object : Callback<ExecuteOrderResponse> {
             override fun onResponse(

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/repository/InAppPurchasesRepository.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/repository/InAppPurchasesRepository.kt
@@ -47,12 +47,16 @@ class InAppPurchasesRepository(private var iapAPI: InAppPurchasesAPI) {
         basketId: Long,
         productId: String,
         purchaseToken: String,
+        price: Long?,
+        currencyCode: String?,
         callback: NetworkResponseCallback<ExecuteOrderResponse>
     ) {
         iapAPI.executeOrder(
             basketId = basketId,
             productId = productId,
-            purchaseToken = purchaseToken
+            purchaseToken = purchaseToken,
+            price = price,
+            currencyCode = currencyCode,
         ).enqueue(object : Callback<ExecuteOrderResponse> {
             override fun onResponse(
                 call: Call<ExecuteOrderResponse>,

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.kt
@@ -241,7 +241,7 @@ class CourseUnitMobileNotSupportedFragment : CourseUnitFragment() {
                 iapViewModel.startPurchaseFlow(
                     productId,
                     skuDetail.getPriceAmount(),
-                    skuDetail.priceCurrencyCode
+                    skuDetail.priceCurrencyCode,
                 )
             } ?: iapDialog.showPreUpgradeErrorDialog(this)
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.kt
@@ -17,6 +17,7 @@ import org.edx.mobile.extenstion.isNotVisible
 import org.edx.mobile.extenstion.setImageDrawable
 import org.edx.mobile.extenstion.setVisibility
 import org.edx.mobile.http.HttpStatus
+import org.edx.mobile.inapppurchases.getPriceAmount
 import org.edx.mobile.model.api.AuthorizationDenialReason
 import org.edx.mobile.model.api.EnrolledCoursesResponse
 import org.edx.mobile.model.course.CourseComponent
@@ -237,7 +238,11 @@ class CourseUnitMobileNotSupportedFragment : CourseUnitFragment() {
         binding.layoutUpgradeBtn.btnUpgrade.setOnClickListener {
             iapAnalytics.trackIAPEvent(Events.IAP_UPGRADE_NOW_CLICKED)
             unit?.courseSku?.let { productId ->
-                iapViewModel.startPurchaseFlow(productId)
+                iapViewModel.startPurchaseFlow(
+                    productId,
+                    skuDetail.getPriceAmount(),
+                    skuDetail.priceCurrencyCode
+                )
             } ?: iapDialog.showPreUpgradeErrorDialog(this)
         }
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
@@ -182,7 +182,7 @@ class CourseModalDialogFragment : DialogFragment() {
                 iapViewModel.startPurchaseFlow(
                     it,
                     skuDetails.getPriceAmount(),
-                    skuDetails.priceCurrencyCode
+                    skuDetails.priceCurrencyCode,
                 )
             } ?: iapDialog.showPreUpgradeErrorDialog(this)
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
@@ -17,6 +17,7 @@ import org.edx.mobile.event.IAPFlowEvent
 import org.edx.mobile.exception.ErrorMessage
 import org.edx.mobile.extenstion.setVisibility
 import org.edx.mobile.http.HttpStatus
+import org.edx.mobile.inapppurchases.getPriceAmount
 import org.edx.mobile.model.iap.IAPFlowData
 import org.edx.mobile.module.analytics.Analytics
 import org.edx.mobile.module.analytics.Analytics.Events
@@ -178,7 +179,11 @@ class CourseModalDialogFragment : DialogFragment() {
         binding.layoutUpgradeBtn.btnUpgrade.setOnClickListener {
             iapAnalytics.trackIAPEvent(eventName = Events.IAP_UPGRADE_NOW_CLICKED)
             courseSku?.let {
-                iapViewModel.startPurchaseFlow(it)
+                iapViewModel.startPurchaseFlow(
+                    it,
+                    skuDetails.getPriceAmount(),
+                    skuDetails.priceCurrencyCode
+                )
             } ?: iapDialog.showPreUpgradeErrorDialog(this)
         }
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/InAppPurchasesViewModel.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/InAppPurchasesViewModel.kt
@@ -110,7 +110,7 @@ class InAppPurchasesViewModel @Inject constructor(
         } ?: dispatchError(requestType = ErrorMessage.PRICE_CODE)
     }
 
-    fun startPurchaseFlow(productId: String, priceAmount: Float, currencyCode: String) {
+    fun startPurchaseFlow(productId: String, priceAmount: Double, currencyCode: String) {
         iapFlowData.productId = productId
         iapFlowData.priceAmount = priceAmount
         iapFlowData.currencyCode = currencyCode

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/InAppPurchasesViewModel.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/InAppPurchasesViewModel.kt
@@ -110,9 +110,9 @@ class InAppPurchasesViewModel @Inject constructor(
         } ?: dispatchError(requestType = ErrorMessage.PRICE_CODE)
     }
 
-    fun startPurchaseFlow(productId: String, price: Long, currencyCode: String) {
+    fun startPurchaseFlow(productId: String, priceAmount: Float, currencyCode: String) {
         iapFlowData.productId = productId
-        iapFlowData.price = price
+        iapFlowData.priceAmount = priceAmount
         iapFlowData.currencyCode = currencyCode
         iapFlowData.flowType = IAPFlowData.IAPFlowType.USER_INITIATED
         iapFlowData.isVerificationPending = true
@@ -180,7 +180,7 @@ class InAppPurchasesViewModel @Inject constructor(
                 basketId = iapData.basketId,
                 productId = iapData.productId,
                 purchaseToken = iapData.purchaseToken,
-                price = iapData.price,
+                priceAmount = iapData.priceAmount,
                 currencyCode = iapData.currencyCode,
                 callback = object : NetworkResponseCallback<ExecuteOrderResponse> {
                     override fun onSuccess(result: Result.Success<ExecuteOrderResponse>) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/InAppPurchasesViewModel.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/InAppPurchasesViewModel.kt
@@ -110,8 +110,10 @@ class InAppPurchasesViewModel @Inject constructor(
         } ?: dispatchError(requestType = ErrorMessage.PRICE_CODE)
     }
 
-    fun startPurchaseFlow(productId: String) {
+    fun startPurchaseFlow(productId: String, price: Long, currencyCode: String) {
         iapFlowData.productId = productId
+        iapFlowData.price = price
+        iapFlowData.currencyCode = currencyCode
         iapFlowData.flowType = IAPFlowData.IAPFlowType.USER_INITIATED
         iapFlowData.isVerificationPending = true
         addProductToBasket()
@@ -178,6 +180,8 @@ class InAppPurchasesViewModel @Inject constructor(
                 basketId = iapData.basketId,
                 productId = iapData.productId,
                 purchaseToken = iapData.purchaseToken,
+                price = iapData.price,
+                currencyCode = iapData.currencyCode,
                 callback = object : NetworkResponseCallback<ExecuteOrderResponse> {
                     override fun onSuccess(result: Result.Success<ExecuteOrderResponse>) {
                         result.data?.let {


### PR DESCRIPTION

### Description

[LEARNER-9396](https://2u-internal.atlassian.net/browse/LEARNER-9396)

- Add price and currency_code parameters in execute API's request body
- Fetch price for restore/unfulfilled purchases