### PR TITLE
refactor: Resolve build-time warnings after Android 13 migration

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -119,14 +119,14 @@ dependencies {
     // NOTE: Always update the version of google-services and firebase libraries using the ones
     // provided in this link: https://developers.google.com/android/guides/releases
     implementation "com.google.android.gms:play-services-plus:17.0.0"
-    implementation "com.google.android.gms:play-services-analytics:18.0.2"
-    implementation "com.google.android.gms:play-services-auth:20.5.0"
+    implementation "com.google.android.gms:play-services-analytics:18.0.3"
+    implementation "com.google.android.gms:play-services-auth:20.6.0"
     // Google Firebase
     implementation "com.google.firebase:firebase-core:21.1.1"
     implementation "com.google.firebase:firebase-messaging:23.1.2"
 
     // Add the dependency for the Performance Monitoring library
-    implementation "com.google.firebase:firebase-perf:20.3.2"
+    implementation "com.google.firebase:firebase-perf:20.3.3"
     // Firebase remote config
     implementation "com.google.firebase:firebase-config:21.4.0"
 
@@ -163,7 +163,7 @@ dependencies {
     implementation "androidx.multidex:multidex:2.0.1"
     implementation "androidx.constraintlayout:constraintlayout:2.1.4"
     implementation "de.hdodenhof:circleimageview:2.0.0"
-    implementation "com.github.bumptech.glide:glide:4.11.0"
+    implementation "com.github.bumptech.glide:glide:4.14.2"
     implementation "com.github.bumptech.glide:okhttp3-integration:4.11.0"
 
     // Segment Library
@@ -239,7 +239,7 @@ dependencies {
     androidTestImplementation "junit:junit:4.13.2"
     androidTestImplementation "androidx.test.ext:junit:1.1.5"
     androidTestImplementation "androidx.test:rules:1.5.0"
-    androidTestImplementation "org.hamcrest:hamcrest-library:1.3"
+    androidTestImplementation "org.hamcrest:hamcrest-library:2.2"
     androidTestImplementation "androidx.test.espresso:espresso-core:3.5.1"
     androidTestImplementation "com.linkedin.dexmaker:dexmaker-mockito:2.12.1"
     androidTestImplementation("org.mockito:mockito-core:5.3.1") {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragment.java
@@ -1,6 +1,5 @@
 package org.edx.mobile.base;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
@@ -19,8 +18,8 @@ public class BaseFragment extends Fragment {
 
     private boolean isFirstVisit = true;
 
-    protected ActivityResultLauncher<String> requestPermissionLauncher =
-            registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
+    protected ActivityResultLauncher<String> requestPermissionLauncher = registerForActivityResult(
+            new ActivityResultContracts.RequestPermission(), isGranted -> {
                 if (!isGranted) {
                     showPermissionDeniedMessage();
                 }
@@ -88,15 +87,15 @@ public class BaseFragment extends Fragment {
 
     /**
      * Called when a Fragment is re-displayed to the user (the user has navigated back to it).
-     * Defined to mock the behavior of {@link Activity#onRestart() Activity.onRestart} function.
+     * Defined to mock the behavior of {@link `Activity#onRestart()` Activity.onRestart} function.
      */
     protected void onRevisit() {
     }
 
     /**
-     * Called when a parent activity receives a new intent in its {@link Activity#onNewIntent(Intent)
+     * Called when a parent activity receives a new intent in its {@link `Activity#onNewIntent(Intent)`
      * Activity.onNewIntent} function.
-     * Defined to mock the behavior of {@link Activity#onNewIntent(Intent) Activity.onNewIntent} function.
+     * Defined to mock the behavior of {@link `Activity#onNewIntent(Intent)` Activity.onNewIntent} function.
      */
     protected void onNewIntent(Intent intent) {
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/WebViewCourseInfoFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/WebViewCourseInfoFragment.java
@@ -10,6 +10,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.URLUtil;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -26,7 +28,6 @@ import dagger.hilt.android.AndroidEntryPoint;
 public class WebViewCourseInfoFragment extends BaseWebViewFragment
         implements WebViewStatusListener {
 
-    private static final int LOG_IN_REQUEST_CODE = 42;
     private static final String INSTANCE_COURSE_ID = "enrollCourseId";
     private static final String INSTANCE_EMAIL_OPT_IN = "enrollEmailOptIn";
 
@@ -36,6 +37,13 @@ public class WebViewCourseInfoFragment extends BaseWebViewFragment
     private DefaultActionListener defaultActionListener;
 
     private FragmentWebviewBinding binding;
+
+    private final ActivityResultLauncher<Intent> enrollCourseResult = registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(), result -> {
+                if (result.getResultCode() == Activity.RESULT_OK) {
+                    defaultActionListener.onClickEnroll(lastClickEnrollCourseId, lastClickEnrollEmailOptIn);
+                }
+            });
 
     @Nullable
     @Override
@@ -56,14 +64,14 @@ public class WebViewCourseInfoFragment extends BaseWebViewFragment
     }
 
     @Override
-    public void onSaveInstanceState(Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putString(INSTANCE_COURSE_ID, lastClickEnrollCourseId);
         outState.putBoolean(INSTANCE_EMAIL_OPT_IN, lastClickEnrollEmailOptIn);
     }
 
     public void setWebViewActionListener() {
-        defaultActionListener = new DefaultActionListener(getActivity(), progressWheel,
+        defaultActionListener = new DefaultActionListener(requireActivity(), progressWheel,
                 new DefaultActionListener.EnrollCallback() {
                     @Override
                     public void onResponse(@NonNull EnrolledCoursesResponse course) {
@@ -78,7 +86,7 @@ public class WebViewCourseInfoFragment extends BaseWebViewFragment
                     public void onUserNotLoggedIn(@NonNull String courseId, boolean emailOptIn) {
                         lastClickEnrollCourseId = courseId;
                         lastClickEnrollEmailOptIn = emailOptIn;
-                        startActivityForResult(environment.getRouter().getRegisterIntent(), LOG_IN_REQUEST_CODE);
+                        enrollCourseResult.launch(environment.getRouter().getRegisterIntent());
                     }
                 });
         client.setActionListener(defaultActionListener);
@@ -89,16 +97,8 @@ public class WebViewCourseInfoFragment extends BaseWebViewFragment
         return new FullScreenErrorNotification(binding.webview);
     }
 
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-        if (requestCode == LOG_IN_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
-            defaultActionListener.onClickEnroll(lastClickEnrollCourseId, lastClickEnrollEmailOptIn);
-        }
-    }
-
     /**
-     * Loads the given URL into {@link #webView}.
+     * Loads the given URL into [webview].
      *
      * @param url The URL to load.
      */
@@ -114,7 +114,7 @@ public class WebViewCourseInfoFragment extends BaseWebViewFragment
      * By default, all links will not be treated as external.
      * Depends on host, as long as the links have same host, they are treated as non-external links.
      *
-     * @return
+     * @return True to treat every link as an external link
      */
     protected boolean isAllLinksExternal() {
         return true;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/WebViewCourseInfoFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/WebViewCourseInfoFragment.java
@@ -38,7 +38,7 @@ public class WebViewCourseInfoFragment extends BaseWebViewFragment
 
     private FragmentWebviewBinding binding;
 
-    private final ActivityResultLauncher<Intent> enrollCourseResult = registerForActivityResult(
+    private final ActivityResultLauncher<Intent> loginRequestLauncher = registerForActivityResult(
             new ActivityResultContracts.StartActivityForResult(), result -> {
                 if (result.getResultCode() == Activity.RESULT_OK) {
                     defaultActionListener.onClickEnroll(lastClickEnrollCourseId, lastClickEnrollEmailOptIn);
@@ -86,7 +86,7 @@ public class WebViewCourseInfoFragment extends BaseWebViewFragment
                     public void onUserNotLoggedIn(@NonNull String courseId, boolean emailOptIn) {
                         lastClickEnrollCourseId = courseId;
                         lastClickEnrollEmailOptIn = emailOptIn;
-                        enrollCourseResult.launch(environment.getRouter().getRegisterIntent());
+                        loginRequestLauncher.launch(environment.getRouter().getRegisterIntent());
                     }
                 });
         client.setActionListener(defaultActionListener);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/event/FileSelectionEvent.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/event/FileSelectionEvent.kt
@@ -1,5 +1,7 @@
 package org.edx.mobile.event
 
-import android.net.Uri
+import android.content.Intent
 
-data class FileSelectionEvent(val files: Array<Uri>?) : BaseEvent()
+class FileSelectionEvent(
+    val intent: Intent
+) : BaseEvent()

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/event/FileSelectionEvent.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/event/FileSelectionEvent.kt
@@ -2,6 +2,4 @@ package org.edx.mobile.event
 
 import android.content.Intent
 
-class FileSelectionEvent(
-    val intent: Intent
-) : BaseEvent()
+class FileSelectionEvent(val intent: Intent) : BaseEvent()

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/event/FileShareEvent.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/event/FileShareEvent.kt
@@ -2,6 +2,4 @@ package org.edx.mobile.event
 
 import android.net.Uri
 
-class FileShareEvent(
-    val files: Array<Uri>?
-) : BaseEvent()
+class FileShareEvent(val files: Array<Uri>?) : BaseEvent()

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/event/FileShareEvent.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/event/FileShareEvent.kt
@@ -1,0 +1,7 @@
+package org.edx.mobile.event
+
+import android.net.Uri
+
+class FileShareEvent(
+    val files: Array<Uri>?
+) : BaseEvent()

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/BundleExt.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/BundleExt.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.os.Parcelable
 import java.io.Serializable
 
-
 inline fun <reified T : Serializable> Bundle.serializable(key: String): T? {
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         getSerializable(key, T::class.java)

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/BundleExt.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/BundleExt.kt
@@ -1,0 +1,39 @@
+package org.edx.mobile.extenstion
+
+import android.os.Build
+import android.os.Bundle
+import android.os.Parcelable
+import java.io.Serializable
+
+
+inline fun <reified T : Serializable> Bundle.serializable(key: String): T? {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getSerializable(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getSerializable(key) as? T
+    }
+}
+
+@Throws(IllegalStateException::class)
+inline fun <reified T : Serializable> Bundle?.serializableOrThrow(key: String): T {
+    return this?.serializable(key) ?: run {
+        throw IllegalStateException("No arguments available")
+    }
+}
+
+inline fun <reified T : Parcelable> Bundle.parcelable(key: String): T? {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getParcelable(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getParcelable(key) as? T
+    }
+}
+
+@Throws(IllegalStateException::class)
+inline fun <reified T : Parcelable> Bundle?.parcelableOrThrow(key: String): T {
+    return this?.parcelable(key) ?: run {
+        throw IllegalStateException("No arguments available")
+    }
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/IntentExt.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/IntentExt.kt
@@ -1,0 +1,15 @@
+package org.edx.mobile.extenstion
+
+import android.content.Intent
+import android.os.Build
+import java.io.Serializable
+
+
+inline fun <reified T : Serializable> Intent.serializable(key: String): T? {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getSerializableExtra(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getSerializableExtra(key) as? T
+    }
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/IntentExt.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/IntentExt.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.os.Build
 import java.io.Serializable
 
-
 inline fun <reified T : Serializable> Intent.serializable(key: String): T? {
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         getSerializableExtra(key, T::class.java)

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/TextViewExt.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/TextViewExt.kt
@@ -7,7 +7,6 @@ import android.text.style.URLSpan
 import android.text.util.Linkify
 import android.widget.TextView
 import androidx.core.text.HtmlCompat
-import androidx.core.text.HtmlCompat.FROM_HTML_MODE_COMPACT
 
 fun TextView.renderHtml(body: String) {
     parseHtml(body)?.let { spannedHtml ->
@@ -31,7 +30,7 @@ fun TextView.renderHtml(body: String) {
 private fun parseHtml(html: String): Spanned? {
     // If the HTML contains a paragraph at the end, there will be blank lines following the text
     // Therefore, we need to trim the resulting CharSequence to remove those extra lines
-    return trim(HtmlCompat.fromHtml(html, FROM_HTML_MODE_COMPACT)) as Spanned?
+    return trim(HtmlCompat.fromHtml(html, HtmlCompat.FROM_HTML_MODE_COMPACT)) as Spanned?
 }
 
 private fun trim(s: CharSequence): CharSequence {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/TextViewExt.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/TextViewExt.kt
@@ -1,12 +1,13 @@
 package org.edx.mobile.extenstion
 
-import android.text.Html
 import android.text.SpannableString
 import android.text.Spanned
 import android.text.method.LinkMovementMethod
 import android.text.style.URLSpan
 import android.text.util.Linkify
 import android.widget.TextView
+import androidx.core.text.HtmlCompat
+import androidx.core.text.HtmlCompat.FROM_HTML_MODE_COMPACT
 
 fun TextView.renderHtml(body: String) {
     parseHtml(body)?.let { spannedHtml ->
@@ -14,7 +15,7 @@ fun TextView.renderHtml(body: String) {
             0, spannedHtml.length,
             URLSpan::class.java
         )
-        this.autoLinkMask = Linkify.ALL
+        this.autoLinkMask = Linkify.EMAIL_ADDRESSES or Linkify.PHONE_NUMBERS or Linkify.WEB_URLS
         this.movementMethod = LinkMovementMethod.getInstance()
         this.text = spannedHtml
         val viewText = this.text as SpannableString
@@ -30,10 +31,10 @@ fun TextView.renderHtml(body: String) {
 private fun parseHtml(html: String): Spanned? {
     // If the HTML contains a paragraph at the end, there will be blank lines following the text
     // Therefore, we need to trim the resulting CharSequence to remove those extra lines
-    return trim(Html.fromHtml(html)) as Spanned?
+    return trim(HtmlCompat.fromHtml(html, FROM_HTML_MODE_COMPACT)) as Spanned?
 }
 
-private fun trim(s: CharSequence): CharSequence? {
+private fun trim(s: CharSequence): CharSequence {
     var start = 0
     var end = s.length
     while (start < end && Character.isWhitespace(s[start])) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/social/facebook/FacebookAuth.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/social/facebook/FacebookAuth.java
@@ -3,6 +3,8 @@ package org.edx.mobile.social.facebook;
 import android.app.Activity;
 import android.content.Intent;
 
+import androidx.annotation.NonNull;
+
 import com.facebook.CallbackManager;
 import com.facebook.FacebookCallback;
 import com.facebook.FacebookException;
@@ -20,7 +22,7 @@ public class FacebookAuth extends ISocialImpl {
         super(activity);
         callbackManager = CallbackManager.Factory.create();
         LoginManager.getInstance().registerCallback(callbackManager,
-                new FacebookCallback<LoginResult>() {
+                new FacebookCallback<>() {
                     @Override
                     public void onSuccess(LoginResult loginResult) {
                         if (callback != null) {
@@ -35,7 +37,7 @@ public class FacebookAuth extends ISocialImpl {
                     }
 
                     @Override
-                    public void onError(FacebookException error) {
+                    public void onError(@NonNull FacebookException error) {
                         logger.error(error);
                     }
                 });

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/social/facebook/FacebookAuth.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/social/facebook/FacebookAuth.java
@@ -3,8 +3,6 @@ package org.edx.mobile.social.facebook;
 import android.app.Activity;
 import android.content.Intent;
 
-import androidx.annotation.NonNull;
-
 import com.facebook.CallbackManager;
 import com.facebook.FacebookCallback;
 import com.facebook.FacebookException;
@@ -22,7 +20,7 @@ public class FacebookAuth extends ISocialImpl {
         super(activity);
         callbackManager = CallbackManager.Factory.create();
         LoginManager.getInstance().registerCallback(callbackManager,
-                new FacebookCallback<>() {
+                new FacebookCallback<LoginResult>() {
                     @Override
                     public void onSuccess(LoginResult loginResult) {
                         if (callback != null) {
@@ -37,7 +35,7 @@ public class FacebookAuth extends ISocialImpl {
                     }
 
                     @Override
-                    public void onError(@NonNull FacebookException error) {
+                    public void onError(FacebookException error) {
                         logger.error(error);
                     }
                 });

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/FileUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/FileUtil.java
@@ -280,9 +280,10 @@ public class FileUtil {
     }
 
     /**
-     * Method to initiate the file selector with given supported file extensions.
+     * Creates an Intent to pick files with specified extensions.
      *
-     * @return
+     * @param acceptTypes An array of MIME types to filter file selection.
+     * @return An Intent for the file picker activity.
      */
     public static Intent getChooseFilesIntent(String[] acceptTypes) {
         Intent intent = new Intent(Intent.ACTION_GET_CONTENT);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/FileUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/FileUtil.java
@@ -11,9 +11,7 @@ import android.webkit.MimeTypeMap;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RawRes;
-import androidx.fragment.app.FragmentActivity;
 
-import org.edx.mobile.R;
 import org.edx.mobile.core.IEdxEnvironment;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.VideoModel;
@@ -34,7 +32,6 @@ public class FileUtil {
     protected static final Logger logger = new Logger(FileUtil.class.getName());
 
     private static final int DEFAULT_BUFFER_SIZE = 1024 * 4;
-    public static final int FILE_CHOOSER_RESULT_CODE = 0x001;
 
     // Make this class non-instantiable
     private FileUtil() {
@@ -284,14 +281,15 @@ public class FileUtil {
 
     /**
      * Method to initiate the file selector with given supported file extensions.
+     *
+     * @return
      */
-    public static void chooseFiles(FragmentActivity activity, String[] acceptTypes) {
+    public static Intent getChooseFilesIntent(String[] acceptTypes) {
         Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
         intent.setType("*/*");
         intent.putExtra(Intent.EXTRA_MIME_TYPES, getSupportedFileMimeType(acceptTypes));
         intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
-        activity.startActivityForResult(Intent.createChooser(intent, activity.getString(R.string.choose_file_title)),
-                FILE_CHOOSER_RESULT_CODE);
+        return intent;
     }
 
     /**

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/PermissionsUtil.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/PermissionsUtil.kt
@@ -1,18 +1,12 @@
 package org.edx.mobile.util
 
-import android.annotation.TargetApi
+import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.content.ContextCompat
-import androidx.fragment.app.Fragment
 
 object PermissionsUtil {
-    const val WRITE_STORAGE_PERMISSION_REQUEST = 1
-    const val CAMERA_PERMISSION_REQUEST = 2
-    const val READ_STORAGE_PERMISSION_REQUEST = 3
-    const val CALENDAR_PERMISSION_REQUEST = 4
-    const val POST_NOTIFICATION_REQUEST = 5
 
     @JvmStatic
     fun checkPermissions(permission: String, context: Context): Boolean {
@@ -22,8 +16,11 @@ object PermissionsUtil {
     }
 
     @JvmStatic
-    @TargetApi(Build.VERSION_CODES.M)
-    fun requestPermissions(requestCode: Int, permissions: Array<String>, fragment: Fragment) {
-        fragment.requestPermissions(permissions, requestCode)
+    fun getReadStoragePermission(): String {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            Manifest.permission.READ_MEDIA_IMAGES
+        } else {
+            Manifest.permission.READ_EXTERNAL_STORAGE
+        }
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/AuthenticatedWebViewActivity.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/AuthenticatedWebViewActivity.kt
@@ -47,7 +47,7 @@ class AuthenticatedWebViewActivity : BaseSingleFragmentActivity() {
         @JvmStatic
         fun newIntent(activity: Context?, unit: CourseComponent): Intent {
             return newIntent(
-                activity,
+                activity = activity,
                 url = unit.blockUrl,
                 screenTitle = unit.displayName,
                 isModalView = false

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/AuthenticatedWebViewActivity.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/AuthenticatedWebViewActivity.kt
@@ -3,6 +3,7 @@ package org.edx.mobile.view
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import dagger.hilt.android.AndroidEntryPoint
 import org.edx.mobile.base.BaseSingleFragmentActivity
@@ -12,6 +13,14 @@ import org.edx.mobile.model.course.CourseComponent
 class AuthenticatedWebViewActivity : BaseSingleFragmentActivity() {
 
     private var isModalView: Boolean = false
+    private val onBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            if (isModalView.not()) {
+                finish()
+            }
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         title = intent.getStringExtra(EXTRA_SCREEN_TITLE)
@@ -19,6 +28,10 @@ class AuthenticatedWebViewActivity : BaseSingleFragmentActivity() {
         if (isModalView || title.isNullOrEmpty()) {
             supportActionBar?.hide()
         }
+        onBackPressedDispatcher.addCallback(
+            this,
+            onBackPressedCallback
+        )
     }
 
     override fun getFirstFragment(): Fragment {
@@ -33,11 +46,21 @@ class AuthenticatedWebViewActivity : BaseSingleFragmentActivity() {
 
         @JvmStatic
         fun newIntent(activity: Context?, unit: CourseComponent): Intent {
-            return newIntent(activity, url = unit.blockUrl, screenTitle = unit.displayName, isModalView = false)
+            return newIntent(
+                activity,
+                url = unit.blockUrl,
+                screenTitle = unit.displayName,
+                isModalView = false
+            )
         }
 
         @JvmStatic
-        fun newIntent(activity: Context?, url: String, screenTitle: String, isModalView: Boolean): Intent {
+        fun newIntent(
+            activity: Context?,
+            url: String,
+            screenTitle: String,
+            isModalView: Boolean
+        ): Intent {
             val intent = Intent(activity, AuthenticatedWebViewActivity::class.java)
             intent.putExtra(EXTRA_COMPONENT_URL, url)
             intent.putExtra(EXTRA_SCREEN_TITLE, screenTitle)
@@ -47,10 +70,5 @@ class AuthenticatedWebViewActivity : BaseSingleFragmentActivity() {
             }
             return intent
         }
-    }
-
-    override fun onBackPressed() {
-        if (isModalView.not())
-            super.onBackPressed()
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/AuthenticatedWebViewActivity.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/AuthenticatedWebViewActivity.kt
@@ -45,7 +45,7 @@ class AuthenticatedWebViewActivity : BaseSingleFragmentActivity() {
         private const val EXTRA_IS_MODAL_VIEW = "is_modal_view"
 
         @JvmStatic
-        fun newIntent(activity: Context?, unit: CourseComponent): Intent {
+        fun newIntent(activity: Context, unit: CourseComponent): Intent {
             return newIntent(
                 activity = activity,
                 url = unit.blockUrl,
@@ -56,7 +56,7 @@ class AuthenticatedWebViewActivity : BaseSingleFragmentActivity() {
 
         @JvmStatic
         fun newIntent(
-            activity: Context?,
+            activity: Context,
             url: String,
             screenTitle: String,
             isModalView: Boolean

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/BulkDownloadFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/BulkDownloadFragment.java
@@ -121,7 +121,7 @@ public class BulkDownloadFragment extends BaseFragment {
      */
     private final List<VideoModel> removableVideos = new ArrayList<>();
 
-    private final ActivityResultLauncher<String> permissionRequest =
+    private final ActivityResultLauncher<String> storagePermissionLauncher =
             registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
                 if (isGranted) {
                     onPermissionGranted();
@@ -426,7 +426,7 @@ public class BulkDownloadFragment extends BaseFragment {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                     onPermissionGranted();
                 } else {
-                    permissionRequest.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+                    storagePermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE);
                 }
             } else {
                 switchState = SwitchState.USER_TURNED_OFF;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/BulkDownloadFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/BulkDownloadFragment.java
@@ -4,6 +4,7 @@ import android.Manifest;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.Resources;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.HandlerThread;
@@ -14,6 +15,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CompoundButton;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
@@ -37,7 +40,6 @@ import org.edx.mobile.module.storage.BulkVideosDownloadStartedEvent;
 import org.edx.mobile.util.DownloadUtil;
 import org.edx.mobile.util.MemoryUtil;
 import org.edx.mobile.util.NetworkUtil;
-import org.edx.mobile.util.PermissionsUtil;
 import org.edx.mobile.util.ResourceUtil;
 import org.edx.mobile.util.VideoUtil;
 import org.edx.mobile.view.adapters.CourseOutlineAdapter;
@@ -54,9 +56,8 @@ import javax.inject.Inject;
 import dagger.hilt.android.AndroidEntryPoint;
 
 @AndroidEntryPoint
-public class BulkDownloadFragment extends BaseFragment implements BaseFragment.PermissionListener {
+public class BulkDownloadFragment extends BaseFragment {
     private final String EXTRA_COURSE_VIDEOS_STATUS = "extra_course_videos_status";
-
 
     protected final Logger logger = new Logger(getClass().getName());
 
@@ -114,11 +115,21 @@ public class BulkDownloadFragment extends BaseFragment implements BaseFragment.P
     /**
      * List of videos that are remaining for download.
      */
-    private List<HasDownloadEntry> remainingVideos = new ArrayList<>();
+    private final List<HasDownloadEntry> remainingVideos = new ArrayList<>();
     /**
      * List of videos that are currently being downloaded or have been downloaded.
      */
-    private List<VideoModel> removableVideos = new ArrayList<>();
+    private final List<VideoModel> removableVideos = new ArrayList<>();
+
+    private final ActivityResultLauncher<String> permissionRequest =
+            registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
+                if (isGranted) {
+                    onPermissionGranted();
+                } else {
+                    showPermissionDeniedMessage();
+                }
+            });
+
 
     public BulkDownloadFragment() {
     }
@@ -133,22 +144,21 @@ public class BulkDownloadFragment extends BaseFragment implements BaseFragment.P
     }
 
     @Override
-    public void onSaveInstanceState(Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putParcelable(EXTRA_COURSE_VIDEOS_STATUS, videosStatus);
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         binding = RowBulkDownloadBinding.inflate(inflater, container, false);
         return binding.getRoot();
     }
 
     @Override
-    public void onViewCreated(View view, Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        permissionListener = this;
 
         final HandlerThread handlerThread = new HandlerThread("BulkDownloadBgThread");
         handlerThread.start();
@@ -192,7 +202,7 @@ public class BulkDownloadFragment extends BaseFragment implements BaseFragment.P
 
         // Get all the videos of this course from DB that we have downloaded or are downloading
         environment.getDatabase().getVideosByVideoIds(totalDownloadableVideos, null,
-                new DataCallback<List<VideoModel>>() {
+                new DataCallback<>() {
                     @Override
                     public void onResult(final List<VideoModel> result) {
                         for (CourseComponent video : totalDownloadableVideos) {
@@ -202,24 +212,24 @@ public class BulkDownloadFragment extends BaseFragment implements BaseFragment.P
                                     final DownloadEntry.DownloadedState downloadedState =
                                             DownloadEntry.DownloadedState.values()[dbVideo.getDownloadedStateOrdinal()];
                                     switch (downloadedState) {
-                                        case DOWNLOADED:
+                                        case DOWNLOADED -> {
                                             videosStatus.downloaded++;
                                             videosStatus.totalVideosSize += dbVideo.getSize();
                                             removableVideos.add(dbVideo);
-                                            break;
-                                        case DOWNLOADING:
+                                        }
+                                        case DOWNLOADING -> {
                                             videosStatus.downloading++;
                                             videosStatus.remaining++;
                                             videosStatus.remainingVideosSize += dbVideo.getSize();
                                             videosStatus.totalVideosSize += dbVideo.getSize();
                                             removableVideos.add(dbVideo);
-                                            break;
-                                        default:
+                                        }
+                                        default -> {
                                             videosStatus.remaining++;
                                             videosStatus.remainingVideosSize += dbVideo.getSize();
                                             videosStatus.totalVideosSize += dbVideo.getSize();
                                             remainingVideos.add((VideoBlockModel) video);
-                                            break;
+                                        }
                                     }
                                     foundInDb = true;
                                     break;
@@ -312,12 +322,7 @@ public class BulkDownloadFragment extends BaseFragment implements BaseFragment.P
                     "remaining_videos_count", videosStatus.remaining + "", "remaining_videos_size",
                     MemoryUtil.format(getContext(), videosStatus.remainingVideosSize));
 
-            binding.getRoot().setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    downloadListener.viewDownloadsStatus();
-                }
-            });
+            binding.getRoot().setOnClickListener(v -> downloadListener.viewDownloadsStatus());
             ViewCompat.setImportantForAccessibility(binding.getRoot(), ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_YES);
             setSwitchAccessibility(R.string.switch_on_all_downloading);
         } else if (switchState == SwitchState.IN_PROCESS) {
@@ -326,12 +331,7 @@ public class BulkDownloadFragment extends BaseFragment implements BaseFragment.P
                     "remaining_videos_count", videosStatus.remaining + "", "remaining_videos_size",
                     MemoryUtil.format(getContext(), videosStatus.remainingVideosSize));
 
-            binding.getRoot().setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    downloadListener.viewDownloadsStatus();
-                }
-            });
+            binding.getRoot().setOnClickListener(v -> downloadListener.viewDownloadsStatus());
             ViewCompat.setImportantForAccessibility(binding.getRoot(), ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO);
             setSwitchAccessibility(R.string.switch_on_all_downloading);
         } else {
@@ -376,11 +376,11 @@ public class BulkDownloadFragment extends BaseFragment implements BaseFragment.P
 
     private void setSwitchState() {
         switch (switchState) {
-            case USER_TURNED_ON:
+            case USER_TURNED_ON -> {
                 binding.swDownload.setChecked(true);
                 binding.swDownload.setEnabled(true);
-                break;
-            case IN_PROCESS:
+            }
+            case IN_PROCESS -> {
                 binding.swDownload.setChecked(true);
                 binding.swDownload.setEnabled(false);
                 if (videosStatus.allVideosDownloading(switchState)) {
@@ -389,8 +389,8 @@ public class BulkDownloadFragment extends BaseFragment implements BaseFragment.P
                     userPrefs.setBulkDownloadSwitchState(switchState, videosStatus.courseComponentId);
                     setSwitchState();
                 }
-                break;
-            case USER_TURNED_OFF:
+            }
+            case USER_TURNED_OFF -> {
                 binding.swDownload.setChecked(false);
                 binding.swDownload.setEnabled(true);
                 if ((videosStatus.allVideosDownloading(switchState) || videosStatus.allVideosDownloaded())
@@ -401,11 +401,11 @@ public class BulkDownloadFragment extends BaseFragment implements BaseFragment.P
                     userPrefs.setBulkDownloadSwitchState(switchState, videosStatus.courseComponentId);
                     setSwitchState();
                 }
-                break;
-            case DEFAULT:
+            }
+            case DEFAULT -> {
                 binding.swDownload.setChecked(videosStatus.allVideosDownloaded() || videosStatus.allVideosDownloading(switchState));
                 binding.swDownload.setEnabled(true);
-                break;
+            }
         }
     }
 
@@ -420,30 +420,29 @@ public class BulkDownloadFragment extends BaseFragment implements BaseFragment.P
     }
 
     private void initDownloadSwitch() {
-        binding.swDownload.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                final CompoundButton buttonView = (CompoundButton) v;
-                if (buttonView.isChecked()) {
-                    askForPermission(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
-                            PermissionsUtil.WRITE_STORAGE_PERMISSION_REQUEST);
+        binding.swDownload.setOnClickListener(v -> {
+            final CompoundButton buttonView = (CompoundButton) v;
+            if (buttonView.isChecked()) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    onPermissionGranted();
                 } else {
-                    switchState = SwitchState.USER_TURNED_OFF;
-                    userPrefs.setBulkDownloadSwitchState(switchState, videosStatus.courseComponentId);
-                    // Delete all videos after a delay
-                    startVideosDeletion();
-                    bgThreadHandler.removeCallbacks(PROGRESS_RUNNABLE);
-                    updateUI();
-
-                    environment.getAnalyticsRegistry().trackBulkDownloadSwitchOff(
-                            videosStatus.courseComponentId, videosStatus.total);
+                    permissionRequest.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE);
                 }
+            } else {
+                switchState = SwitchState.USER_TURNED_OFF;
+                userPrefs.setBulkDownloadSwitchState(switchState, videosStatus.courseComponentId);
+                // Delete all videos after a delay
+                startVideosDeletion();
+                bgThreadHandler.removeCallbacks(PROGRESS_RUNNABLE);
+                updateUI();
+
+                environment.getAnalyticsRegistry().trackBulkDownloadSwitchOff(
+                        videosStatus.courseComponentId, videosStatus.total);
             }
         });
     }
 
-    @Override
-    public void onPermissionGranted(String[] permissions, int requestCode) {
+    public void onPermissionGranted() {
         //FIXME: This check should be removed within scope of this story LEARNER-2177
         if (downloadListener == null) {
             return;
@@ -462,10 +461,6 @@ public class BulkDownloadFragment extends BaseFragment implements BaseFragment.P
 
         environment.getAnalyticsRegistry().trackBulkDownloadSwitchOn(
                 videosStatus.courseComponentId, videosStatus.total, videosStatus.remaining);
-    }
-
-    @Override
-    public void onPermissionDenied(String[] permissions, int requestCode) {
     }
 
     private void startVideosDeletion() {
@@ -495,22 +490,19 @@ public class BulkDownloadFragment extends BaseFragment implements BaseFragment.P
     final Runnable PROGRESS_RUNNABLE = new Runnable() {
 
         public void run() {
-            final Context context = getContext();
+            final Context context = requireContext();
             if (!isValidState() || !NetworkUtil.isConnected(context)) {
                 return;
             }
 
             if (!videosStatus.allVideosDownloading(switchState)) {
-                binding.pbDownload.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        binding.pbDownload.setVisibility(View.GONE);
-                        updateUI();
-                    }
+                binding.pbDownload.post(() -> {
+                    binding.pbDownload.setVisibility(View.GONE);
+                    updateUI();
                 });
             } else {
                 environment.getStorage().getDownloadProgressOfVideos(totalDownloadableVideos,
-                        new DataCallback<NativeDownloadModel>() {
+                        new DataCallback<>() {
                             @Override
                             public void onResult(final NativeDownloadModel downloadModel) {
                                 if (downloadModel != null && isValidState()) {
@@ -527,16 +519,13 @@ public class BulkDownloadFragment extends BaseFragment implements BaseFragment.P
                                             videosStatus.totalVideosSize, videosStatus.totalVideosSize - remainingSizeToDownload);
 
                                     if (videosStatus.allVideosDownloading(switchState) && remainingSizeToDownload > 0) {
-                                        binding.pbDownload.post(new Runnable() {
-                                            @Override
-                                            public void run() {
-                                                binding.pbDownload.setVisibility(View.VISIBLE);
-                                                binding.pbDownload.setProgress(percentageDownloaded);
-                                                setSubtitle(binding.tvSubtitle.getResources().getString(R.string.download_remaining),
-                                                        "remaining_videos_count", videosStatus.remaining + "", "remaining_videos_size",
-                                                        MemoryUtil.format(context, remainingSizeToDownload));
-                                                setSwitchAccessibility(R.string.switch_on_all_downloading);
-                                            }
+                                        binding.pbDownload.post(() -> {
+                                            binding.pbDownload.setVisibility(View.VISIBLE);
+                                            binding.pbDownload.setProgress(percentageDownloaded);
+                                            setSubtitle(binding.tvSubtitle.getResources().getString(R.string.download_remaining),
+                                                    "remaining_videos_count", videosStatus.remaining + "", "remaining_videos_size",
+                                                    MemoryUtil.format(context, remainingSizeToDownload));
+                                            setSwitchAccessibility(R.string.switch_on_all_downloading);
                                         });
                                     }
                                 }
@@ -586,6 +575,7 @@ public class BulkDownloadFragment extends BaseFragment implements BaseFragment.P
     }
 
     @Subscribe
+    @SuppressWarnings("unused")
     public void onEvent(BulkVideosDownloadCancelledEvent event) {
         if (getView() == null) {
             // If fragment view is not created yet, mark the event and fire it once the view is created.
@@ -599,6 +589,7 @@ public class BulkDownloadFragment extends BaseFragment implements BaseFragment.P
     }
 
     @Subscribe
+    @SuppressWarnings("unused")
     public void onEvent(BulkVideosDownloadStartedEvent event) {
         if (getView() == null) {
             // If fragment view is not created yet, mark the event and fire it once the view is created.
@@ -627,7 +618,7 @@ public class BulkDownloadFragment extends BaseFragment implements BaseFragment.P
         }
 
         boolean allVideosDownloading(SwitchState switchState) {
-            return (total == downloaded + downloading) || (switchState != null && switchState == SwitchState.USER_TURNED_ON);
+            return (total == downloaded + downloading) || (switchState == SwitchState.USER_TURNED_ON);
         }
 
         void reset() {
@@ -636,6 +627,7 @@ public class BulkDownloadFragment extends BaseFragment implements BaseFragment.P
             courseComponentId = null;
         }
 
+        @NonNull
         @SuppressLint("DefaultLocale")
         @Override
         public String toString() {
@@ -673,7 +665,7 @@ public class BulkDownloadFragment extends BaseFragment implements BaseFragment.P
         }
 
         @SuppressWarnings("unused")
-        public static final Parcelable.Creator<CourseVideosStatus> CREATOR = new Parcelable.Creator<CourseVideosStatus>() {
+        public static final Parcelable.Creator<CourseVideosStatus> CREATOR = new Parcelable.Creator<>() {
             @Override
             public CourseVideosStatus createFromParcel(Parcel in) {
                 return new CourseVideosStatus(in);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/BulkDownloadFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/BulkDownloadFragment.java
@@ -121,8 +121,8 @@ public class BulkDownloadFragment extends BaseFragment {
      */
     private final List<VideoModel> removableVideos = new ArrayList<>();
 
-    private final ActivityResultLauncher<String> storagePermissionLauncher =
-            registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
+    private final ActivityResultLauncher<String> storagePermissionLauncher = registerForActivityResult(
+            new ActivityResultContracts.RequestPermission(), isGranted -> {
                 if (isGranted) {
                     onPermissionGranted();
                 } else {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseAnnouncementsActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseAnnouncementsActivity.java
@@ -94,13 +94,6 @@ public class CourseAnnouncementsActivity extends BaseSingleFragmentActivity {
         outState.putSerializable(Router.EXTRA_COURSE_DATA, courseData);
     }
 
-
-    @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-        finish();
-    }
-
     @Override
     public Fragment getFirstFragment() {
         CourseAnnouncementsFragment fragment = new CourseAnnouncementsFragment();

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
@@ -160,16 +160,10 @@ public abstract class CourseBaseActivity extends BaseFragmentActivity
     }
 
     @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-        finish();
-    }
-
-    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         // Manually handle backPress button on toolbar
         if (item.getItemId() == android.R.id.home) {
-            onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         }
         return super.onOptionsItemSelected(item);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDatesPageFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDatesPageFragment.kt
@@ -1,6 +1,6 @@
 package org.edx.mobile.view
 
-import android.app.Activity.RESULT_OK
+import android.app.Activity
 import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -51,7 +51,7 @@ class CourseDatesPageFragment : OfflineSupportBaseFragment() {
     private val courseUnitDetailResult =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             val resultData = result.data
-            if (result?.resultCode == RESULT_OK && resultData != null) {
+            if (result?.resultCode == Activity.RESULT_OK && resultData != null) {
                 val outlineComp = courseManager.getCourseDataFromAppLevelCache(courseData.courseId)
                 outlineComp?.let {
                     navigateToCourseUnit(resultData, courseData, outlineComp)
@@ -64,14 +64,14 @@ class CourseDatesPageFragment : OfflineSupportBaseFragment() {
             val component =
                 courseManager.getComponentByIdFromAppLevelCache(courseData.courseId, blockId)
             if (blockId.isNotEmpty() && component != null) {
-                val intent = environment.router.getCourseUnitDetailIntent(
+                val courseUnitDetailIntent = environment.router.getCourseUnitDetailIntent(
                     this@CourseDatesPageFragment,
                     courseData,
                     null,
                     blockId,
                     false
                 )
-                courseUnitDetailResult.launch(intent)
+                courseUnitDetailResult.launch(courseUnitDetailIntent)
                 environment.analyticsRegistry.trackDatesCourseComponentTapped(
                     courseData.courseId,
                     component.id,

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDatesPageFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDatesPageFragment.kt
@@ -48,7 +48,7 @@ class CourseDatesPageFragment : OfflineSupportBaseFragment() {
     private lateinit var binding: FragmentCourseDatesPageBinding
     private val viewModel: CourseDateViewModel by viewModels()
 
-    private val courseUnitDetailResult =
+    private val courseUnitDetailLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             val resultData = result.data
             if (result?.resultCode == Activity.RESULT_OK && resultData != null) {
@@ -71,7 +71,7 @@ class CourseDatesPageFragment : OfflineSupportBaseFragment() {
                     blockId,
                     false
                 )
-                courseUnitDetailResult.launch(courseUnitDetailIntent)
+                courseUnitDetailLauncher.launch(courseUnitDetailIntent)
                 environment.analyticsRegistry.trackDatesCourseComponentTapped(
                     courseData.courseId,
                     component.id,
@@ -99,7 +99,7 @@ class CourseDatesPageFragment : OfflineSupportBaseFragment() {
     private var isCalendarExist: Boolean = false
     private lateinit var loaderDialog: AlertDialogFragment
 
-    private val requestPermissions = registerForActivityResult(
+    private val calendarPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
     ) { isGranted ->
         if (isGranted.containsValue(false).not()) {
@@ -406,7 +406,7 @@ class CourseDatesPageFragment : OfflineSupportBaseFragment() {
         val alertDialog =
             AlertDialogFragment.newInstance(title, message, getString(R.string.label_ok),
                 { _, _ ->
-                    requestPermissions.launch(CalendarUtils.permissions)
+                    calendarPermissionLauncher.launch(CalendarUtils.permissions)
                 },
                 getString(R.string.label_do_not_allow),
                 { _, _ ->

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDatesPageFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDatesPageFragment.kt
@@ -17,6 +17,7 @@ import org.edx.mobile.R
 import org.edx.mobile.base.BaseFragment
 import org.edx.mobile.databinding.FragmentCourseDatesPageBinding
 import org.edx.mobile.exception.ErrorMessage
+import org.edx.mobile.extenstion.serializableOrThrow
 import org.edx.mobile.http.HttpStatus
 import org.edx.mobile.http.HttpStatusException
 import org.edx.mobile.http.notifications.FullScreenErrorNotification
@@ -32,6 +33,7 @@ import org.edx.mobile.util.BrowserUtil
 import org.edx.mobile.util.CalendarUtils
 import org.edx.mobile.util.ConfigUtil
 import org.edx.mobile.util.CourseDateUtil
+import org.edx.mobile.util.NonNullObserver
 import org.edx.mobile.util.PermissionsUtil
 import org.edx.mobile.util.ResourceUtil
 import org.edx.mobile.util.UiUtils
@@ -123,8 +125,7 @@ class CourseDatesPageFragment : OfflineSupportBaseFragment(), BaseFragment.Permi
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         permissionListener = this
-
-        courseData = arguments?.getSerializable(Router.EXTRA_COURSE_DATA) as EnrolledCoursesResponse
+        courseData = arguments.serializableOrThrow(Router.EXTRA_COURSE_DATA)
         isSelfPaced = courseData.course.isSelfPaced
         calendarTitle = CalendarUtils.getCourseCalendarTitle(environment, courseData.course.name)
         accountName = CalendarUtils.getUserAccountForSync(environment)
@@ -165,12 +166,12 @@ class CourseDatesPageFragment : OfflineSupportBaseFragment(), BaseFragment.Permi
     }
 
     private fun initObserver() {
-        viewModel.showLoader.observe(viewLifecycleOwner, Observer { showLoader ->
+        viewModel.showLoader.observe(viewLifecycleOwner, NonNullObserver { showLoader ->
             binding.loadingIndicator.loadingIndicator.visibility =
                 if (showLoader) View.VISIBLE else View.GONE
         })
 
-        viewModel.bannerInfo.observe(viewLifecycleOwner, Observer {
+        viewModel.bannerInfo.observe(viewLifecycleOwner, NonNullObserver {
             initDatesBanner(it)
         })
 
@@ -209,11 +210,9 @@ class CourseDatesPageFragment : OfflineSupportBaseFragment(), BaseFragment.Permi
             }
         })
 
-        viewModel.resetCourseDates.observe(viewLifecycleOwner, Observer { resetCourseDates ->
-            if (resetCourseDates != null) {
-                if (!CalendarUtils.isCalendarExists(contextOrThrow, accountName, calendarTitle)) {
-                    showShiftDateSnackBar(true)
-                }
+        viewModel.resetCourseDates.observe(viewLifecycleOwner, NonNullObserver {
+            if (!CalendarUtils.isCalendarExists(contextOrThrow, accountName, calendarTitle)) {
+                showShiftDateSnackBar(true)
             }
         })
 
@@ -255,7 +254,7 @@ class CourseDatesPageFragment : OfflineSupportBaseFragment(), BaseFragment.Permi
             }
         })
 
-        viewModel.swipeRefresh.observe(viewLifecycleOwner, Observer { enableSwipeListener ->
+        viewModel.swipeRefresh.observe(viewLifecycleOwner, NonNullObserver { enableSwipeListener ->
             binding.swipeContainer.isRefreshing = enableSwipeListener
         })
     }
@@ -328,7 +327,7 @@ class CourseDatesPageFragment : OfflineSupportBaseFragment(), BaseFragment.Permi
             screenName = Analytics.Screens.PLS_COURSE_DATES,
             analyticsRegistry = environment.analyticsRegistry,
             courseBannerInfoModel = courseBannerInfo,
-            clickListener = View.OnClickListener { viewModel.resetCourseDatesBanner(courseId = courseData.courseId) })
+            clickListener = { viewModel.resetCourseDatesBanner(courseId = courseData.courseId) })
 
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDetailFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDetailFragment.java
@@ -87,7 +87,7 @@ public class CourseDetailFragment extends BaseFragment {
     @Inject
     IEdxEnvironment environment;
 
-    private final ActivityResultLauncher<Intent> enrollCourseResult = registerForActivityResult(
+    private final ActivityResultLauncher<Intent> loginRequestLauncher = registerForActivityResult(
             new ActivityResultContracts.StartActivityForResult(), result -> {
                 if (result.getResultCode() == Activity.RESULT_OK) {
                     enrollInCourse();
@@ -320,7 +320,7 @@ public class CourseDetailFragment extends BaseFragment {
      */
     public void enrollInCourse() {
         if (!environment.getLoginPrefs().isUserLoggedIn()) {
-            enrollCourseResult.launch(environment.getRouter().getRegisterIntent());
+            loginRequestLauncher.launch(environment.getRouter().getRegisterIntent());
             return;
         }
         environment.getAnalyticsRegistry().trackEnrollClicked(courseDetail.course_id, emailOptIn);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDetailFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDetailFragment.java
@@ -113,13 +113,10 @@ public class CourseDetailFragment extends BaseFragment {
         mHeaderPlayIcon = view.findViewById(R.id.header_play_icon);
         mCourseDetailLayout = view.findViewById(R.id.dashboard_detail);
 
-        mHeaderPlayIcon.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Uri uri = Uri.parse(courseDetail.media.course_video.uri);
-                Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-                startActivity(intent);
-            }
+        mHeaderPlayIcon.setOnClickListener(v -> {
+            Uri uri = Uri.parse(courseDetail.media.course_video.uri);
+            Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+            startActivity(intent);
         });
 
         return view;
@@ -133,7 +130,7 @@ public class CourseDetailFragment extends BaseFragment {
      * Sets the view for About this Course which is retrieved in a later api call.
      */
     @Override
-    public void onViewCreated(View view, Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
         // Short Description
@@ -206,7 +203,7 @@ public class CourseDetailFragment extends BaseFragment {
         if (courseDetail.media.course_video.uri == null || courseDetail.media.course_video.uri.isEmpty()) {
             mHeaderPlayIcon.setEnabled(false);
         } else {
-            mHeaderPlayIcon.setVisibility(mHeaderPlayIcon.VISIBLE);
+            mHeaderPlayIcon.setVisibility(View.VISIBLE);
         }
     }
 
@@ -219,7 +216,7 @@ public class CourseDetailFragment extends BaseFragment {
         final Activity activity = getActivity();
         final TaskProgressCallback pCallback = activity instanceof TaskProgressCallback ? (TaskProgressCallback) activity : null;
         final TaskMessageCallback mCallback = activity instanceof TaskMessageCallback ? (TaskMessageCallback) activity : null;
-        getCourseDetailCall.enqueue(new ErrorHandlingCallback<CourseDetail>(getActivity(),
+        getCourseDetailCall.enqueue(new ErrorHandlingCallback<>(requireActivity(),
                 pCallback, mCallback, CallTrigger.LOADING_CACHED) {
             @Override
             protected void onResponse(@NonNull final CourseDetail courseDetail) {
@@ -239,7 +236,7 @@ public class CourseDetailFragment extends BaseFragment {
      */
     private void populateAboutThisCourse(String overview) {
         courseAbout.setVisibility(View.VISIBLE);
-        URLInterceptorWebViewClient client = new URLInterceptorWebViewClient(getActivity(),
+        URLInterceptorWebViewClient client = new URLInterceptorWebViewClient(requireActivity(),
                 courseAboutWebView, false, null);
         client.setAllLinksAsExternal(true);
 
@@ -270,7 +267,7 @@ public class CourseDetailFragment extends BaseFragment {
         return holder;
     }
 
-    private class ViewHolder {
+    private static class ViewHolder {
         View rowView;
         AppCompatImageView rowIcon;
         TextView rowFieldName;
@@ -309,14 +306,11 @@ public class CourseDetailFragment extends BaseFragment {
             mEnrollButton.setText(R.string.enroll_now_button_text);
         }
 
-        mEnrollButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (!mEnrolled) {
-                    enrollInCourse();
-                } else {
-                    openCourseDashboard();
-                }
+        mEnrollButton.setOnClickListener(v -> {
+            if (!mEnrolled) {
+                enrollInCourse();
+            } else {
+                openCourseDashboard();
             }
         });
     }
@@ -331,7 +325,7 @@ public class CourseDetailFragment extends BaseFragment {
         }
         environment.getAnalyticsRegistry().trackEnrollClicked(courseDetail.course_id, emailOptIn);
         courseApi.enrollInACourse(courseDetail.course_id, emailOptIn)
-                .enqueue(new CourseAPI.EnrollCallback(getActivity(), null) {
+                .enqueue(new CourseAPI.EnrollCallback(requireActivity(), null) {
                     @Override
                     protected void onResponse(@NonNull final ResponseBody responseBody) {
                         super.onResponse(responseBody);
@@ -344,12 +338,12 @@ public class CourseDetailFragment extends BaseFragment {
                             @Override
                             public void run() {
                                 courseApi.getEnrolledCourses().enqueue(new CourseAPI.GetCourseByIdCallback(
-                                        getActivity(),
+                                        requireActivity(),
                                         courseDetail.course_id,
                                         null) {
                                     @Override
                                     protected void onResponse(@NonNull EnrolledCoursesResponse course) {
-                                        environment.getRouter().showCourseDashboardTabs(getActivity(), course, false);
+                                        environment.getRouter().showCourseDashboardTabs(requireActivity(), course, false);
                                     }
                                 });
                             }
@@ -372,13 +366,12 @@ public class CourseDetailFragment extends BaseFragment {
                     executeStrict(courseApi.getEnrolledCoursesFromCache()).getEnrollments();
             for (EnrolledCoursesResponse course : enrolledCoursesResponse) {
                 if (course.getCourse().getId().equals(courseDetail.course_id)) {
-                    environment.getRouter().showCourseDashboardTabs(getActivity(), course, false);
+                    environment.getRouter().showCourseDashboardTabs(requireActivity(), course, false);
                 }
             }
         } catch (Exception exception) {
             logger.debug(exception.toString());
             Toast.makeText(getContext(), R.string.cannot_show_dashboard, Toast.LENGTH_SHORT).show();
         }
-
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -545,7 +545,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment implements
                 listView.clearChoices();
                 final CourseComponent component = adapter.getItem(position).component;
                 if (component.isContainer()) {
-                    Intent courseOutlineIntent = environment.getRouter().getCourseContainerOutlineIntent(CourseOutlineFragment.this,
+                    Intent courseOutlineIntent = environment.getRouter().getCourseOutlineIntent(CourseOutlineFragment.this,
                             courseData, courseUpgradeData, component.getId(), null, isVideoMode);
                     courseUnitDetailResult.launch(courseOutlineIntent);
                 } else {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -164,8 +164,8 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment implements
     private AlertDialogFragment loaderDialog;
     private boolean refreshOnResume = false;
 
-    private final ActivityResultLauncher<Intent> courseUnitDetailLauncher =
-            registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
+    private final ActivityResultLauncher<Intent> courseUnitDetailLauncher = registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(), result -> {
                 Intent resultData = result.getData();
                 if (result.getResultCode() == Activity.RESULT_OK && resultData != null) {
                     if (resultData.getBooleanExtra(AppConstants.COURSE_UPGRADED, false)) {
@@ -545,16 +545,16 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment implements
                 listView.clearChoices();
                 final CourseComponent component = adapter.getItem(position).component;
                 if (component.isContainer()) {
-                    Intent courseOutlineIntent = environment.getRouter().getCourseOutlineIntent(CourseOutlineFragment.this,
+                    Intent courseOutlineIntent = environment.getRouter().getCourseOutlineIntent(requireActivity(),
                             courseData, courseUpgradeData, component.getId(), null, isVideoMode);
                     courseUnitDetailLauncher.launch(courseOutlineIntent);
                 } else {
                     if (adapter.getItemViewType(position) == CourseOutlineAdapter.SectionRow.RESUME_COURSE_ITEM) {
                         environment.getAnalyticsRegistry().trackResumeCourseBannerTapped(component.getCourseId(), component.getId());
                     }
-                    Intent intent = environment.getRouter().getCourseUnitDetailIntent(CourseOutlineFragment.this,
+                    Intent courseUnitDetailIntent = environment.getRouter().getCourseUnitDetailIntent(requireActivity(),
                             courseData, courseUpgradeData, component.getId(), isVideoMode);
-                    courseUnitDetailLauncher.launch(intent);
+                    courseUnitDetailLauncher.launch(courseUnitDetailIntent);
 
                     environment.getAnalyticsRegistry().trackScreenView(
                             Analytics.Screens.UNIT_DETAIL, courseData.getCourse().getId(), component.getParent().getInternalName());
@@ -647,9 +647,9 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment implements
     private void detectDeepLinking() {
         if (Screen.COURSE_COMPONENT.equalsIgnoreCase(screenName)
                 && !TextUtils.isEmpty(courseComponentId)) {
-            Intent intent = environment.getRouter().getCourseUnitDetailIntent(CourseOutlineFragment.this,
+            Intent courseUnitDetailIntent = environment.getRouter().getCourseUnitDetailIntent(requireActivity(),
                     courseData, courseUpgradeData, courseComponentId, false);
-            courseUnitDetailLauncher.launch(intent);
+            courseUnitDetailLauncher.launch(courseUnitDetailIntent);
             screenName = null;
         }
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -164,7 +164,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment implements
     private AlertDialogFragment loaderDialog;
     private boolean refreshOnResume = false;
 
-    private final ActivityResultLauncher<Intent> courseUnitDetailResult =
+    private final ActivityResultLauncher<Intent> courseUnitDetailLauncher =
             registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
                 Intent resultData = result.getData();
                 if (result.getResultCode() == Activity.RESULT_OK && resultData != null) {
@@ -192,7 +192,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment implements
                 }
             });
 
-    private final ActivityResultLauncher<String> storagePermission = registerForActivityResult(
+    private final ActivityResultLauncher<String> storagePermissionLauncher = registerForActivityResult(
             new ActivityResultContracts.RequestPermission(), isGranted -> {
                 if (isGranted) {
                     onPermissionGranted();
@@ -547,14 +547,14 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment implements
                 if (component.isContainer()) {
                     Intent courseOutlineIntent = environment.getRouter().getCourseOutlineIntent(CourseOutlineFragment.this,
                             courseData, courseUpgradeData, component.getId(), null, isVideoMode);
-                    courseUnitDetailResult.launch(courseOutlineIntent);
+                    courseUnitDetailLauncher.launch(courseOutlineIntent);
                 } else {
                     if (adapter.getItemViewType(position) == CourseOutlineAdapter.SectionRow.RESUME_COURSE_ITEM) {
                         environment.getAnalyticsRegistry().trackResumeCourseBannerTapped(component.getCourseId(), component.getId());
                     }
                     Intent intent = environment.getRouter().getCourseUnitDetailIntent(CourseOutlineFragment.this,
                             courseData, courseUpgradeData, component.getId(), isVideoMode);
-                    courseUnitDetailResult.launch(intent);
+                    courseUnitDetailLauncher.launch(intent);
 
                     environment.getAnalyticsRegistry().trackScreenView(
                             Analytics.Screens.UNIT_DETAIL, courseData.getCourse().getId(), component.getParent().getInternalName());
@@ -592,7 +592,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment implements
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                         onPermissionGranted();
                     } else {
-                        storagePermission.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+                        storagePermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE);
                     }
                 }
 
@@ -603,7 +603,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment implements
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                         onPermissionGranted();
                     } else {
-                        storagePermission.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+                        storagePermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE);
                     }
                 }
 
@@ -649,7 +649,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment implements
                 && !TextUtils.isEmpty(courseComponentId)) {
             Intent intent = environment.getRouter().getCourseUnitDetailIntent(CourseOutlineFragment.this,
                     courseData, courseUpgradeData, courseComponentId, false);
-            courseUnitDetailResult.launch(intent);
+            courseUnitDetailLauncher.launch(intent);
             screenName = null;
         }
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitFragment.kt
@@ -5,6 +5,7 @@ import androidx.annotation.NonNull
 import org.edx.mobile.base.BaseFragment
 import org.edx.mobile.core.IEdxEnvironment
 import org.edx.mobile.event.CourseOutlineRefreshEvent
+import org.edx.mobile.extenstion.serializable
 import org.edx.mobile.model.course.CourseComponent
 import org.edx.mobile.services.CourseManager
 import org.greenrobot.eventbus.EventBus
@@ -25,8 +26,7 @@ abstract class CourseUnitFragment : BaseFragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        unit =
-            if (arguments == null) null else arguments?.getSerializable(Router.EXTRA_COURSE_UNIT) as CourseComponent
+        unit = arguments?.serializable(Router.EXTRA_COURSE_UNIT)
     }
 
     fun markComponentCompletion(isCompleted: Boolean) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
@@ -95,7 +95,7 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
     private boolean isVideoMode = false;
     private boolean refreshCourse = false;
 
-    ActivityResultLauncher<Intent> chooseFilesResult = registerForActivityResult(
+    ActivityResultLauncher<Intent> fileChooserLauncher = registerForActivityResult(
             new ActivityResultContracts.StartActivityForResult(), result -> {
                 Uri[] files = null;
                 Intent resultData = result.getData();
@@ -533,7 +533,7 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
 
     @Subscribe
     public void onEvent(FileSelectionEvent event) {
-        chooseFilesResult.launch(event.getIntent());
+        fileChooserLauncher.launch(event.getIntent());
     }
 
     @Subscribe

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
@@ -14,6 +14,7 @@ import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.widget.RelativeLayout;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
@@ -42,6 +43,7 @@ import org.edx.mobile.model.course.EnrollmentMode;
 import org.edx.mobile.model.course.VideoBlockModel;
 import org.edx.mobile.model.iap.IAPFlowData;
 import org.edx.mobile.module.analytics.InAppPurchasesAnalytics;
+import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.NonNullObserver;
 import org.edx.mobile.util.UiUtils;
 import org.edx.mobile.util.VideoUtil;
@@ -118,6 +120,21 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
             }
     );
 
+    private final OnBackPressedCallback onBackPressedCallback = new OnBackPressedCallback(true) {
+        @Override
+        public void handleOnBackPressed() {
+            // Add result data into the intent to trigger the signal that `courseData` is updated after
+            // the course was purchased from a locked component screen.
+            if (refreshCourse) {
+                Intent resultData = new Intent();
+                resultData.putExtra(AppConstants.COURSE_UPGRADED, true);
+                setResult(RESULT_OK, resultData);
+                refreshCourse = false;
+            }
+            finish();
+        }
+    };
+
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         super.setToolbarAsActionBar();
@@ -143,6 +160,7 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
         if (!isVideoMode) {
             getCourseCelebrationStatus();
         }
+        getOnBackPressedDispatcher().addCallback(this, onBackPressedCallback);
     }
 
     private void initAdapter() {
@@ -431,19 +449,6 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
             pager2.setCurrentItem(index, false);
             tryToUpdateForEndOfSequential();
         }
-    }
-
-    @Override
-    public void onBackPressed() {
-        // Add result data into the intent to trigger the signal that `courseData` is updated after
-        // the course was purchased from a locked component screen.
-        if (refreshCourse) {
-            Intent resultData = new Intent();
-            resultData.putExtra(AppConstants.COURSE_UPGRADED, true);
-            setResult(RESULT_OK, resultData);
-            refreshCourse = false;
-        }
-        super.onBackPressed();
     }
 
     @Override

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
@@ -76,7 +76,7 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
     private ViewPager2 pager2;
     private CourseComponent selectedUnit;
 
-    private List<CourseComponent> unitList = new ArrayList<>();
+    private final List<CourseComponent> unitList = new ArrayList<>();
     private CourseUnitPagerAdapter pagerAdapter;
     private InAppPurchasesViewModel iapViewModel;
 
@@ -96,7 +96,8 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
     private boolean refreshCourse = false;
 
     ActivityResultLauncher<Intent> fileChooserLauncher = registerForActivityResult(
-            new ActivityResultContracts.StartActivityForResult(), result -> {
+            new ActivityResultContracts.StartActivityForResult(),
+            result -> {
                 Uri[] files = null;
                 Intent resultData = result.getData();
                 if (result.getResultCode() == Activity.RESULT_OK && resultData != null) {
@@ -138,7 +139,7 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         super.setToolbarAsActionBar();
-        RelativeLayout insertPoint = (RelativeLayout) findViewById(R.id.fragment_container);
+        RelativeLayout insertPoint = findViewById(R.id.fragment_container);
         LayoutInflater inflater = (LayoutInflater) getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 
         @NonNull ViewCourseUnitPagerBinding binding = ViewCourseUnitPagerBinding.inflate(inflater, null, false);
@@ -194,7 +195,7 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
 
     private void getCourseCelebrationStatus() {
         Call<CourseStatus> courseStatusCall = courseApi.getCourseStatus(courseData.getCourseId());
-        courseStatusCall.enqueue(new ErrorHandlingCallback<CourseStatus>(this, null, null) {
+        courseStatusCall.enqueue(new ErrorHandlingCallback<>(this, null, null) {
             @Override
             protected void onResponse(@NonNull CourseStatus responseBody) {
                 isFirstSection = responseBody.getCelebrationStatus().getFirstSection();
@@ -223,7 +224,7 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
                         EventBus.getDefault().postSticky(new VideoPlaybackEvent(true));
                         if (!reCreate) {
                             courseApi.updateCourseCelebration(courseData.getCourseId())
-                                    .enqueue(new ErrorHandlingCallback<Void>(CourseUnitNavigationActivity.this) {
+                                    .enqueue(new ErrorHandlingCallback<>(CourseUnitNavigationActivity.this) {
                                         @Override
                                         protected void onResponse(@NonNull Void responseBody) {
                                             isFirstSection = false;
@@ -452,7 +453,7 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
     }
 
     @Override
-    public void onConfigurationChanged(Configuration newConfig) {
+    public void onConfigurationChanged(@NonNull Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
         updateUIForOrientation();
         if (selectedUnit != null) {
@@ -520,14 +521,8 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
             return;
         }
         switch (event.getFlowAction()) {
-            case SHOW_FULL_SCREEN_LOADER: {
-                showFullscreenLoader(event.getIapFlowData());
-                break;
-            }
-            case PURCHASE_FLOW_COMPLETE: {
-                EventBus.getDefault().post(new MyCoursesRefreshEvent());
-                break;
-            }
+            case SHOW_FULL_SCREEN_LOADER -> showFullscreenLoader(event.getIapFlowData());
+            case PURCHASE_FLOW_COMPLETE -> EventBus.getDefault().post(new MyCoursesRefreshEvent());
         }
     }
 
@@ -537,6 +532,7 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
     }
 
     @Subscribe
+    @SuppressWarnings("unused")
     public void onEvent(CourseUpgradedEvent event) {
         finish();
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CropImageActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CropImageActivity.java
@@ -93,7 +93,7 @@ public class CropImageActivity extends BaseFragmentActivity {
         findViewById(R.id.cancel).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                onBackPressed();
+                getOnBackPressedDispatcher().onBackPressed();
             }
         });
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/EditUserProfileFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/EditUserProfileFragment.java
@@ -192,7 +192,7 @@ public class EditUserProfileFragment extends BaseFragment {
 
         parseExtras();
 
-        final Activity activity = getActivity();
+        final Activity activity = requireActivity();
         final TaskMessageCallback mCallback = activity instanceof TaskMessageCallback ? (TaskMessageCallback) activity : null;
         getAccountCall = userService.getAccount(username);
         getAccountCall.enqueue(new AccountDataUpdatedCallback(
@@ -222,7 +222,7 @@ public class EditUserProfileFragment extends BaseFragment {
     }
 
     @Override
-    public void onViewCreated(View view, Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         viewHolder = new ViewHolder(view);
         viewHolder.profileImageProgress.setVisibility(View.GONE);
@@ -232,7 +232,7 @@ public class EditUserProfileFragment extends BaseFragment {
         viewHolder.changePhoto.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                final PopupMenu popup = new PopupMenu(getActivity(), v);
+                final PopupMenu popup = new PopupMenu(requireActivity(), v);
                 popup.getMenuInflater().inflate(R.menu.change_photo, popup.getMenu());
                 popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
                     public boolean onMenuItemClick(MenuItem item) {
@@ -244,7 +244,7 @@ public class EditUserProfileFragment extends BaseFragment {
                                 storagePermission.launch(PermissionsUtil.getReadStoragePermission());
                             }
                             case R.id.remove_photo -> {
-                                final Task<Void> task = new DeleteAccountImageTask(getActivity(), username);
+                                final Task<Void> task = new DeleteAccountImageTask(requireActivity(), username);
                                 task.setProgressDialog(viewHolder.profileImageProgress);
                                 executePhotoTask(task);
                             }
@@ -294,7 +294,7 @@ public class EditUserProfileFragment extends BaseFragment {
     @Subscribe
     @SuppressWarnings("unused")
     public void onEventMainThread(@NonNull ProfilePhotoUpdatedEvent event) {
-        UserProfileUtils.loadProfileImage(getContext(), event, viewHolder.profileImage);
+        UserProfileUtils.loadProfileImage(requireContext(), event, viewHolder.profileImage);
     }
 
     @Subscribe
@@ -449,7 +449,7 @@ public class EditUserProfileFragment extends BaseFragment {
                         createField(layoutInflater, viewHolder.fields, field, displayValue, isLimited && !field.getName().equals(Account.YEAR_OF_BIRTH_SERIALIZED_NAME), new View.OnClickListener() {
                             @Override
                             public void onClick(View v) {
-                                editProfileResult.launch(FormFieldActivity.newIntent(getActivity(), field, value));
+                                editProfileResult.launch(FormFieldActivity.newIntent(requireActivity(), field, value));
                             }
                         });
                         break;
@@ -486,7 +486,7 @@ public class EditUserProfileFragment extends BaseFragment {
             valueObject = fieldValue;
         }
         userService.updateAccount(username, Collections.singletonMap(field.getName(), valueObject))
-                .enqueue(new AccountDataUpdatedCallback(getActivity(), username,
+                .enqueue(new AccountDataUpdatedCallback(requireActivity(), username,
                         new DialogErrorNotification(this)) {
                     @Override
                     protected void onResponse(@NonNull final Account account) {
@@ -540,7 +540,7 @@ public class EditUserProfileFragment extends BaseFragment {
         final TextView textView = (TextView) inflater.inflate(R.layout.edit_user_profile_field, parent, false);
         final SpannableString formattedValue = new SpannableString(value);
         formattedValue.setSpan(new ForegroundColorSpan(parent.getResources().getColor(R.color.neutralXXDark)), 0, formattedValue.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-        textView.setText(ResourceUtil.getFormattedString(parent.getResources(), R.string.edit_user_profile_field, new HashMap<String, CharSequence>() {{
+        textView.setText(ResourceUtil.getFormattedString(parent.getResources(), R.string.edit_user_profile_field, new HashMap<>() {{
             put("label", field.getLabel());
             put("value", formattedValue);
         }}));

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/EditUserProfileFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/EditUserProfileFragment.java
@@ -121,23 +121,22 @@ public class EditUserProfileFragment extends BaseFragment {
                 }
             });
 
-    private final ActivityResultLauncher<Intent> photoChooserLauncher =
-            registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
+    private final ActivityResultLauncher<Intent> photoChooserLauncher = registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(),
+            result -> {
                 Intent resultData = result.getData();
                 if (result.getResultCode() == Activity.RESULT_OK && resultData != null) {
                     Uri imageUri = resultData.getData();
                     if (imageUri != null) {
-                        photoCropLauncher.launch(
-                                CropImageActivity.newIntent(
-                                        requireActivity(), imageUri, false
-                                )
-                        );
+                        photoCropLauncher.launch(CropImageActivity.newIntent(requireActivity(), imageUri, false));
                     }
                 }
-            });
+            }
+    );
 
-    private final ActivityResultLauncher<Intent> photoCaptureLauncher =
-            registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
+    private final ActivityResultLauncher<Intent> photoCaptureLauncher = registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(),
+            result -> {
                 if (result.getResultCode() == Activity.RESULT_OK) {
                     Uri imageUri = helper.getImageUriFromResult();
                     if (imageUri != null) {
@@ -150,20 +149,24 @@ public class EditUserProfileFragment extends BaseFragment {
                         photoCropLauncher.launch(CropImageActivity.newIntent(requireActivity(), imageUri, true));
                     }
                 }
-            });
+            }
+    );
 
-    private final ActivityResultLauncher<Intent> editProfileLauncher =
-            registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
+    private final ActivityResultLauncher<Intent> editProfileLauncher = registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(),
+            result -> {
                 Intent resultData = result.getData();
                 if (result.getResultCode() == Activity.RESULT_OK && resultData != null) {
                     final FormField fieldName = (FormField) resultData.getSerializableExtra(FormFieldActivity.EXTRA_FIELD);
                     final String fieldValue = resultData.getStringExtra(FormFieldActivity.EXTRA_VALUE);
                     executeUpdate(fieldName, fieldValue);
                 }
-            });
+            }
+    );
 
-    private final ActivityResultLauncher<String> storagePermissionLauncher =
-            registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
+    private final ActivityResultLauncher<String> storagePermissionLauncher = registerForActivityResult(
+            new ActivityResultContracts.RequestPermission(),
+            isGranted -> {
                 if (isGranted) {
                     final Intent galleryIntent = new Intent()
                             .setType("image/*")
@@ -172,10 +175,12 @@ public class EditUserProfileFragment extends BaseFragment {
                 } else {
                     showPermissionDeniedMessage();
                 }
-            });
+            }
+    );
 
-    private final ActivityResultLauncher<String> cameraPermissionLauncher =
-            registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
+    private final ActivityResultLauncher<String> cameraPermissionLauncher = registerForActivityResult(
+            new ActivityResultContracts.RequestPermission(),
+            isGranted -> {
                 if (isGranted) {
                     photoCaptureLauncher.launch(helper.createCaptureIntent(requireActivity()));
                 } else {
@@ -237,12 +242,10 @@ public class EditUserProfileFragment extends BaseFragment {
                 popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
                     public boolean onMenuItemClick(MenuItem item) {
                         switch (item.getItemId()) {
-                            case R.id.take_photo -> {
-                                cameraPermissionLauncher.launch(Manifest.permission.CAMERA);
-                            }
-                            case R.id.choose_photo -> {
-                                storagePermissionLauncher.launch(PermissionsUtil.getReadStoragePermission());
-                            }
+                            case R.id.take_photo ->
+                                    cameraPermissionLauncher.launch(Manifest.permission.CAMERA);
+                            case R.id.choose_photo ->
+                                    storagePermissionLauncher.launch(PermissionsUtil.getReadStoragePermission());
                             case R.id.remove_photo -> {
                                 final Task<Void> task = new DeleteAccountImageTask(requireActivity(), username);
                                 task.setProgressDialog(viewHolder.profileImageProgress);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/EditUserProfileFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/EditUserProfileFragment.java
@@ -106,7 +106,7 @@ public class EditUserProfileFragment extends BaseFragment {
     @NonNull
     private final ImageCaptureHelper helper = new ImageCaptureHelper();
 
-    private final ActivityResultLauncher<Intent> cropPhotoResult =
+    private final ActivityResultLauncher<Intent> photoCropLauncher =
             registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
                 Intent resultData = result.getData();
                 if (result.getResultCode() == Activity.RESULT_OK && resultData != null) {
@@ -121,13 +121,13 @@ public class EditUserProfileFragment extends BaseFragment {
                 }
             });
 
-    private final ActivityResultLauncher<Intent> choosePhotoResult =
+    private final ActivityResultLauncher<Intent> photoChooserLauncher =
             registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
                 Intent resultData = result.getData();
                 if (result.getResultCode() == Activity.RESULT_OK && resultData != null) {
                     Uri imageUri = resultData.getData();
                     if (imageUri != null) {
-                        cropPhotoResult.launch(
+                        photoCropLauncher.launch(
                                 CropImageActivity.newIntent(
                                         requireActivity(), imageUri, false
                                 )
@@ -136,7 +136,7 @@ public class EditUserProfileFragment extends BaseFragment {
                 }
             });
 
-    private final ActivityResultLauncher<Intent> capturePhotoResult =
+    private final ActivityResultLauncher<Intent> photoCaptureLauncher =
             registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
                 if (result.getResultCode() == Activity.RESULT_OK) {
                     Uri imageUri = helper.getImageUriFromResult();
@@ -147,12 +147,12 @@ public class EditUserProfileFragment extends BaseFragment {
                         if (rotatedImageUri != null) {
                             imageUri = rotatedImageUri;
                         }
-                        cropPhotoResult.launch(CropImageActivity.newIntent(requireActivity(), imageUri, true));
+                        photoCropLauncher.launch(CropImageActivity.newIntent(requireActivity(), imageUri, true));
                     }
                 }
             });
 
-    private final ActivityResultLauncher<Intent> editProfileResult =
+    private final ActivityResultLauncher<Intent> editProfileLauncher =
             registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
                 Intent resultData = result.getData();
                 if (result.getResultCode() == Activity.RESULT_OK && resultData != null) {
@@ -162,22 +162,22 @@ public class EditUserProfileFragment extends BaseFragment {
                 }
             });
 
-    private final ActivityResultLauncher<String> storagePermission =
+    private final ActivityResultLauncher<String> storagePermissionLauncher =
             registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
                 if (isGranted) {
                     final Intent galleryIntent = new Intent()
                             .setType("image/*")
                             .setAction(Intent.ACTION_GET_CONTENT);
-                    choosePhotoResult.launch(galleryIntent);
+                    photoChooserLauncher.launch(galleryIntent);
                 } else {
                     showPermissionDeniedMessage();
                 }
             });
 
-    private final ActivityResultLauncher<String> cameraPermission =
+    private final ActivityResultLauncher<String> cameraPermissionLauncher =
             registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
                 if (isGranted) {
-                    capturePhotoResult.launch(helper.createCaptureIntent(requireActivity()));
+                    photoCaptureLauncher.launch(helper.createCaptureIntent(requireActivity()));
                 } else {
                     showPermissionDeniedMessage();
                 }
@@ -238,10 +238,10 @@ public class EditUserProfileFragment extends BaseFragment {
                     public boolean onMenuItemClick(MenuItem item) {
                         switch (item.getItemId()) {
                             case R.id.take_photo -> {
-                                cameraPermission.launch(Manifest.permission.CAMERA);
+                                cameraPermissionLauncher.launch(Manifest.permission.CAMERA);
                             }
                             case R.id.choose_photo -> {
-                                storagePermission.launch(PermissionsUtil.getReadStoragePermission());
+                                storagePermissionLauncher.launch(PermissionsUtil.getReadStoragePermission());
                             }
                             case R.id.remove_photo -> {
                                 final Task<Void> task = new DeleteAccountImageTask(requireActivity(), username);
@@ -449,7 +449,7 @@ public class EditUserProfileFragment extends BaseFragment {
                         createField(layoutInflater, viewHolder.fields, field, displayValue, isLimited && !field.getName().equals(Account.YEAR_OF_BIRTH_SERIALIZED_NAME), new View.OnClickListener() {
                             @Override
                             public void onClick(View v) {
-                                editProfileResult.launch(FormFieldActivity.newIntent(requireActivity(), field, value));
+                                editProfileLauncher.launch(FormFieldActivity.newIntent(requireActivity(), field, value));
                             }
                         });
                         break;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/LockedCourseUnitFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/LockedCourseUnitFragment.kt
@@ -7,6 +7,8 @@ import android.view.ViewGroup
 import dagger.hilt.android.AndroidEntryPoint
 import org.edx.mobile.R
 import org.edx.mobile.databinding.FragmentLockedCourseUnitBinding
+import org.edx.mobile.extenstion.parcelableOrThrow
+import org.edx.mobile.extenstion.serializableOrThrow
 import org.edx.mobile.model.api.CourseUpgradeResponse
 import org.edx.mobile.model.api.EnrolledCoursesResponse
 import org.edx.mobile.model.course.CourseComponent
@@ -48,9 +50,9 @@ class LockedCourseUnitFragment : CourseUnitFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val courseUpgradeData =
-            arguments?.getParcelable<CourseUpgradeResponse>(Router.EXTRA_COURSE_UPGRADE_DATA) as CourseUpgradeResponse
+            arguments.parcelableOrThrow<CourseUpgradeResponse>(Router.EXTRA_COURSE_UPGRADE_DATA)
         val courseData =
-            arguments?.getSerializable(Router.EXTRA_COURSE_DATA) as EnrolledCoursesResponse
+            arguments.serializableOrThrow<EnrolledCoursesResponse>(Router.EXTRA_COURSE_DATA)
         loadPaymentBannerFragment(courseData, courseUpgradeData)
         analyticsRegistry.trackScreenView(Analytics.Screens.COURSE_UNIT_LOCKED)
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/MainTabsDashboardFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/MainTabsDashboardFragment.java
@@ -15,7 +15,6 @@ import org.edx.mobile.event.MoveToDiscoveryTabEvent;
 import org.edx.mobile.event.ScreenArgumentsEvent;
 import org.edx.mobile.model.FragmentItemModel;
 import org.edx.mobile.module.analytics.Analytics;
-import org.edx.mobile.util.PermissionsUtil;
 import org.edx.mobile.util.UiUtils;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
@@ -110,20 +109,7 @@ public class MainTabsDashboardFragment extends TabsBaseFragment {
     private void requestPostNotificationsPermission() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
                 !shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
-            permissionListener = new PermissionListener() {
-                @Override
-                public void onPermissionGranted(String[] permissions, int requestCode) {
-                }
-
-                @Override
-                public void onPermissionDenied(String[] permissions, int requestCode) {
-                }
-            };
-
-            askForPermission(
-                    new String[]{Manifest.permission.POST_NOTIFICATIONS},
-                    PermissionsUtil.POST_NOTIFICATION_REQUEST
-            );
+            requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS);
         }
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.kt
@@ -177,6 +177,7 @@ class MyCoursesListFragment : OfflineSupportBaseFragment(), RefreshListener {
                                 )
                             }
                         }
+
                         HttpStatus.UPGRADE_REQUIRED -> {
                             context?.let { context ->
                                 errorNotification.showError(
@@ -187,6 +188,7 @@ class MyCoursesListFragment : OfflineSupportBaseFragment(), RefreshListener {
                         }
                     }
                 }
+
                 (FullscreenLoaderDialogFragment
                     .getRetainedInstance(fragmentManager = childFragmentManager)?.isAdded == true) -> {
                     iapViewModel.dispatchError(
@@ -194,6 +196,7 @@ class MyCoursesListFragment : OfflineSupportBaseFragment(), RefreshListener {
                         errorMessage = it.message
                     )
                 }
+
                 else -> {
                     showError(it)
                 }
@@ -301,6 +304,7 @@ class MyCoursesListFragment : OfflineSupportBaseFragment(), RefreshListener {
                     showFullscreenLoader(event.iapFlowData)
                 }
             }
+
             IAPFlowData.IAPAction.PURCHASE_FLOW_COMPLETE -> {
                 courseViewModel.fetchEnrolledCourses(type = CoursesRequestType.LIVE)
             }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.kt
@@ -23,6 +23,7 @@ import org.edx.mobile.event.MoveToDiscoveryTabEvent
 import org.edx.mobile.event.MyCoursesRefreshEvent
 import org.edx.mobile.event.NetworkConnectivityChangeEvent
 import org.edx.mobile.exception.ErrorMessage
+import org.edx.mobile.extenstion.parcelable
 import org.edx.mobile.extenstion.setVisibility
 import org.edx.mobile.http.HttpStatus
 import org.edx.mobile.http.HttpStatusException
@@ -345,12 +346,10 @@ class MyCoursesListFragment : OfflineSupportBaseFragment(), RefreshListener {
     }
 
     private fun detectDeeplink() {
-        if (arguments?.get(Router.EXTRA_DEEP_LINK) != null) {
-            (arguments?.get(Router.EXTRA_DEEP_LINK) as DeepLink).let { deeplink ->
-                DeepLinkManager.proceedDeeplink(requireActivity(), deeplink)
-                MainApplication.instance().showBanner(loginAPI, true)
-            }
-        } else {
+        arguments?.parcelable<DeepLink>(Router.EXTRA_DEEP_LINK)?.let {
+            DeepLinkManager.proceedDeeplink(requireActivity(), it)
+            MainApplication.instance().showBanner(loginAPI, true)
+        } ?: run {
             MainApplication.instance().showBanner(loginAPI, false)
         }
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/OfflineSupportBaseFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/OfflineSupportBaseFragment.kt
@@ -92,7 +92,7 @@ abstract class OfflineSupportBaseFragment : BaseFragment() {
                 var i = outlinePathSize + 1
                 while (i < leafPathSize - 1) {
                     val nextComp = leafPath[i]
-                    val intent = environment.router?.getCourseContainerOutlineIntent(
+                    val intent = environment.router?.getCourseOutlineIntent(
                         this@OfflineSupportBaseFragment,
                         courseData, null,
                         nextComp.id, leafCompId, false

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/OfflineSupportBaseFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/OfflineSupportBaseFragment.kt
@@ -88,7 +88,7 @@ abstract class OfflineSupportBaseFragment : BaseFragment() {
                 while (i < leafPathSize - 1) {
                     val nextComp = leafPath[i]
                     val intent = environment.router?.getCourseOutlineIntent(
-                        this@OfflineSupportBaseFragment,
+                        requireActivity(),
                         courseData, null,
                         nextComp.id, leafCompId, false
                     )

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/OfflineSupportBaseFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/OfflineSupportBaseFragment.kt
@@ -2,10 +2,13 @@ package org.edx.mobile.view
 
 import android.app.Activity
 import android.content.Intent
+import androidx.activity.result.contract.ActivityResultContracts
 import org.edx.mobile.base.BaseFragment
 import org.edx.mobile.core.IEdxEnvironment
 import org.edx.mobile.event.NetworkConnectivityChangeEvent
 import org.edx.mobile.extenstion.serializable
+import org.edx.mobile.http.notifications.FullScreenErrorNotification
+import org.edx.mobile.http.notifications.SnackbarErrorNotification
 import org.edx.mobile.model.api.EnrolledCoursesResponse
 import org.edx.mobile.model.course.CourseComponent
 import org.edx.mobile.services.CourseManager
@@ -34,6 +37,10 @@ abstract class OfflineSupportBaseFragment : BaseFragment() {
      * `false` otherwise.
      */
     protected abstract fun isShowingFullScreenError(): Boolean
+
+    private val courseContainerResult =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        }
 
     override fun onResume() {
         super.onResume()
@@ -85,10 +92,12 @@ abstract class OfflineSupportBaseFragment : BaseFragment() {
                 var i = outlinePathSize + 1
                 while (i < leafPathSize - 1) {
                     val nextComp = leafPath[i]
-                    environment.router?.showCourseContainerOutline(
-                            this@OfflineSupportBaseFragment,
-                            REQUEST_SHOW_COURSE_UNIT_DETAIL, courseData, null,
-                            nextComp.id, leafCompId, false)
+                    val intent = environment.router?.getCourseContainerOutlineIntent(
+                        this@OfflineSupportBaseFragment,
+                        courseData, null,
+                        nextComp.id, leafCompId, false
+                    )
+                    courseContainerResult.launch(intent)
                     i += 2
                 }
             }
@@ -102,9 +111,5 @@ abstract class OfflineSupportBaseFragment : BaseFragment() {
      */
     open fun canUpdateRowSelection(): Boolean {
         return false
-    }
-
-    companion object {
-        const val REQUEST_SHOW_COURSE_UNIT_DETAIL = 101
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/OfflineSupportBaseFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/OfflineSupportBaseFragment.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import org.edx.mobile.base.BaseFragment
 import org.edx.mobile.core.IEdxEnvironment
 import org.edx.mobile.event.NetworkConnectivityChangeEvent
+import org.edx.mobile.extenstion.serializable
 import org.edx.mobile.model.api.EnrolledCoursesResponse
 import org.edx.mobile.model.course.CourseComponent
 import org.edx.mobile.services.CourseManager
@@ -61,10 +62,15 @@ abstract class OfflineSupportBaseFragment : BaseFragment() {
      * Method to redirect the user to course outline screen for maintaining the
      * back stack in case when user directly move to the course unit detail screen.
      */
-    fun navigateToCourseUnit(data: Intent, courseData: EnrolledCoursesResponse, outlineComp: CourseComponent) {
-        val leafCompId = data.getSerializableExtra(Router.EXTRA_COURSE_COMPONENT_ID) as String
-        val leafComp = courseManager.getComponentByIdFromAppLevelCache(
-                courseData.courseId, leafCompId)
+    fun navigateToCourseUnit(
+        data: Intent,
+        courseData: EnrolledCoursesResponse,
+        outlineComp: CourseComponent
+    ) {
+        val leafCompId = data.serializable<String>(Router.EXTRA_COURSE_COMPONENT_ID)
+        val leafComp = leafCompId?.let {
+            courseManager.getComponentByIdFromAppLevelCache(courseData.courseId, it)
+        }
         val outlinePath = outlineComp.path
         val leafPath = leafComp?.path
         val outlinePathSize = outlinePath.path.size

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/OfflineSupportBaseFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/OfflineSupportBaseFragment.kt
@@ -2,7 +2,6 @@ package org.edx.mobile.view
 
 import android.app.Activity
 import android.content.Intent
-import androidx.activity.result.contract.ActivityResultContracts
 import org.edx.mobile.base.BaseFragment
 import org.edx.mobile.core.IEdxEnvironment
 import org.edx.mobile.event.NetworkConnectivityChangeEvent
@@ -37,10 +36,6 @@ abstract class OfflineSupportBaseFragment : BaseFragment() {
      * `false` otherwise.
      */
     protected abstract fun isShowingFullScreenError(): Boolean
-
-    private val courseContainerResult =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-        }
 
     override fun onResume() {
         super.onResume()
@@ -97,7 +92,7 @@ abstract class OfflineSupportBaseFragment : BaseFragment() {
                         courseData, null,
                         nextComp.id, leafCompId, false
                     )
-                    courseContainerResult.launch(intent)
+                    intent?.let { startActivity(it) }
                     i += 2
                 }
             }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/PaymentsBannerFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/PaymentsBannerFragment.kt
@@ -14,6 +14,9 @@ import org.edx.mobile.R
 import org.edx.mobile.base.BaseFragment
 import org.edx.mobile.core.IEdxEnvironment
 import org.edx.mobile.databinding.FragmentPaymentsBannerBinding
+import org.edx.mobile.extenstion.parcelableOrThrow
+import org.edx.mobile.extenstion.serializable
+import org.edx.mobile.extenstion.serializableOrThrow
 import org.edx.mobile.model.api.CourseUpgradeResponse
 import org.edx.mobile.model.api.EnrolledCoursesResponse
 import org.edx.mobile.model.course.CourseComponent
@@ -86,9 +89,9 @@ class PaymentsBannerFragment : BaseFragment() {
 
     private fun populateCourseUpgradeBanner(context: Context) {
         val courseUpgradeData: CourseUpgradeResponse =
-            arguments?.getParcelable<CourseUpgradeResponse>(Router.EXTRA_COURSE_UPGRADE_DATA) as CourseUpgradeResponse
+            arguments.parcelableOrThrow(Router.EXTRA_COURSE_UPGRADE_DATA)
         val courseData: EnrolledCoursesResponse =
-            arguments?.getSerializable(Router.EXTRA_COURSE_DATA) as EnrolledCoursesResponse
+            arguments.serializableOrThrow(Router.EXTRA_COURSE_DATA)
         val showInfoButton: Boolean = arguments?.getBoolean(EXTRA_SHOW_INFO_BUTTON) ?: false
         binding.upgradeToVerifiedFooter.visibility = View.VISIBLE
         if (showInfoButton) {
@@ -109,8 +112,7 @@ class PaymentsBannerFragment : BaseFragment() {
             binding.tvUpgradePrice.visibility = View.GONE
         }
 
-        val courseUnit: CourseComponent? =
-            arguments?.getSerializable(Router.EXTRA_COURSE_UNIT) as CourseComponent?
+        val courseUnit: CourseComponent? = arguments?.serializable(Router.EXTRA_COURSE_UNIT)
 
         courseUpgradeData.basketUrl?.let { basketUrl ->
             binding.llUpgradeButton.setOnClickListener {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/PaymentsInfoFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/PaymentsInfoFragment.kt
@@ -14,7 +14,7 @@ import org.edx.mobile.model.api.EnrolledCoursesResponse
 import org.edx.mobile.util.DateUtil
 import org.edx.mobile.util.ResourceUtil
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Locale
 
 class PaymentsInfoFragment : BaseFragment() {
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/PaymentsInfoFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/PaymentsInfoFragment.kt
@@ -7,6 +7,8 @@ import android.view.ViewGroup
 import org.edx.mobile.R
 import org.edx.mobile.base.BaseFragment
 import org.edx.mobile.databinding.FragmentPaymentsInfoBinding
+import org.edx.mobile.extenstion.parcelableOrThrow
+import org.edx.mobile.extenstion.serializableOrThrow
 import org.edx.mobile.model.api.CourseUpgradeResponse
 import org.edx.mobile.model.api.EnrolledCoursesResponse
 import org.edx.mobile.util.DateUtil
@@ -39,7 +41,7 @@ class PaymentsInfoFragment : BaseFragment() {
         val context = view.context
         binding.btnClose.setOnClickListener { activity?.finish() }
         val courseData =
-            arguments?.getSerializable(Router.EXTRA_COURSE_DATA) as EnrolledCoursesResponse
+            arguments.serializableOrThrow<EnrolledCoursesResponse>(Router.EXTRA_COURSE_DATA)
 
         val dateFormat = SimpleDateFormat("MMM dd, yyyy", Locale.ENGLISH)
         val stringBuilder: StringBuilder = java.lang.StringBuilder()
@@ -76,7 +78,8 @@ class PaymentsInfoFragment : BaseFragment() {
         binding.tvAuditAccessExpiresDetails.text = stringBuilder.toString()
 
         val courseUpgradeData =
-            arguments?.getParcelable<CourseUpgradeResponse>(Router.EXTRA_COURSE_UPGRADE_DATA) as CourseUpgradeResponse
+            arguments.parcelableOrThrow<CourseUpgradeResponse>(Router.EXTRA_COURSE_UPGRADE_DATA)
+
         PaymentsBannerFragment.loadPaymentsBannerFragment(
             R.id.fragment_container, courseData, null,
             courseUpgradeData, false, childFragmentManager, false

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
@@ -8,7 +8,6 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
 import org.edx.mobile.BuildConfig;
@@ -218,16 +217,16 @@ public class Router {
         activity.startActivity(courseDetail);
     }
 
-    public Intent getCourseOutlineIntent(Fragment fragment,
+    public Intent getCourseOutlineIntent(Activity activity,
                                          EnrolledCoursesResponse courseData,
                                          CourseUpgradeResponse courseUpgradeData,
                                          String courseComponentId,
                                          String lastAccessedId, boolean isVideosMode) {
-        return CourseOutlineActivity.newIntent(fragment.getActivity(),
+        return CourseOutlineActivity.newIntent(activity,
                 courseData, courseUpgradeData, courseComponentId, lastAccessedId, isVideosMode);
     }
 
-    public Intent getCourseUnitDetailIntent(Fragment fragment,
+    public Intent getCourseUnitDetailIntent(Activity activity,
                                             EnrolledCoursesResponse model,
                                             CourseUpgradeResponse courseUpgradeData,
                                             String courseComponentId, boolean isVideosMode) {
@@ -236,7 +235,7 @@ public class Router {
         courseBundle.putParcelable(EXTRA_COURSE_UPGRADE_DATA, courseUpgradeData);
         courseBundle.putSerializable(EXTRA_COURSE_COMPONENT_ID, courseComponentId);
 
-        Intent courseDetailIntent = new Intent(fragment.getActivity(), CourseUnitNavigationActivity.class);
+        Intent courseDetailIntent = new Intent(activity, CourseUnitNavigationActivity.class);
         courseDetailIntent.putExtra(EXTRA_BUNDLE, courseBundle);
         courseDetailIntent.putExtra(EXTRA_IS_VIDEOS_MODE, isVideosMode);
         courseDetailIntent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
@@ -218,29 +218,29 @@ public class Router {
         activity.startActivity(courseDetail);
     }
 
-    public Intent getCourseContainerOutlineIntent(Fragment fragment,
-                                                  EnrolledCoursesResponse courseData,
-                                                  CourseUpgradeResponse courseUpgradeData,
-                                                  String courseComponentId,
-                                                  String lastAccessedId, boolean isVideosMode) {
+    public Intent getCourseOutlineIntent(Fragment fragment,
+                                         EnrolledCoursesResponse courseData,
+                                         CourseUpgradeResponse courseUpgradeData,
+                                         String courseComponentId,
+                                         String lastAccessedId, boolean isVideosMode) {
         return CourseOutlineActivity.newIntent(fragment.getActivity(),
                 courseData, courseUpgradeData, courseComponentId, lastAccessedId, isVideosMode);
     }
 
     public Intent getCourseUnitDetailIntent(Fragment fragment,
-                                          EnrolledCoursesResponse model,
-                                          CourseUpgradeResponse courseUpgradeData,
-                                          String courseComponentId, boolean isVideosMode) {
+                                            EnrolledCoursesResponse model,
+                                            CourseUpgradeResponse courseUpgradeData,
+                                            String courseComponentId, boolean isVideosMode) {
         Bundle courseBundle = new Bundle();
         courseBundle.putSerializable(EXTRA_COURSE_DATA, model);
         courseBundle.putParcelable(EXTRA_COURSE_UPGRADE_DATA, courseUpgradeData);
         courseBundle.putSerializable(EXTRA_COURSE_COMPONENT_ID, courseComponentId);
 
-        Intent courseDetail = new Intent(fragment.getActivity(), CourseUnitNavigationActivity.class);
-        courseDetail.putExtra(EXTRA_BUNDLE, courseBundle);
-        courseDetail.putExtra(EXTRA_IS_VIDEOS_MODE, isVideosMode);
-        courseDetail.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-        return courseDetail;
+        Intent courseDetailIntent = new Intent(fragment.getActivity(), CourseUnitNavigationActivity.class);
+        courseDetailIntent.putExtra(EXTRA_BUNDLE, courseBundle);
+        courseDetailIntent.putExtra(EXTRA_IS_VIDEOS_MODE, isVideosMode);
+        courseDetailIntent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+        return courseDetailIntent;
     }
 
     public void showCourseDiscussionAddPost(@NonNull Activity activity, @Nullable DiscussionTopic discussionTopic, @NonNull EnrolledCoursesResponse courseData) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
@@ -218,21 +218,19 @@ public class Router {
         activity.startActivity(courseDetail);
     }
 
-    public void showCourseContainerOutline(Fragment fragment, int requestCode,
-                                           EnrolledCoursesResponse courseData,
-                                           CourseUpgradeResponse courseUpgradeData,
-                                           String courseComponentId,
-                                           String lastAccessedId, boolean isVideosMode) {
-        Intent courseDetail = CourseOutlineActivity.newIntent(fragment.getActivity(),
+    public Intent getCourseContainerOutlineIntent(Fragment fragment,
+                                                  EnrolledCoursesResponse courseData,
+                                                  CourseUpgradeResponse courseUpgradeData,
+                                                  String courseComponentId,
+                                                  String lastAccessedId, boolean isVideosMode) {
+        return CourseOutlineActivity.newIntent(fragment.getActivity(),
                 courseData, courseUpgradeData, courseComponentId, lastAccessedId, isVideosMode);
-        //TODO - what's the most suitable FLAG?
-        // courseDetail.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-        fragment.startActivityForResult(courseDetail, requestCode);
     }
 
-    public void showCourseUnitDetail(Fragment fragment, int requestCode, EnrolledCoursesResponse model,
-                                     CourseUpgradeResponse courseUpgradeData,
-                                     String courseComponentId, boolean isVideosMode) {
+    public Intent getCourseUnitDetailIntent(Fragment fragment,
+                                          EnrolledCoursesResponse model,
+                                          CourseUpgradeResponse courseUpgradeData,
+                                          String courseComponentId, boolean isVideosMode) {
         Bundle courseBundle = new Bundle();
         courseBundle.putSerializable(EXTRA_COURSE_DATA, model);
         courseBundle.putParcelable(EXTRA_COURSE_UPGRADE_DATA, courseUpgradeData);
@@ -242,7 +240,7 @@ public class Router {
         courseDetail.putExtra(EXTRA_BUNDLE, courseBundle);
         courseDetail.putExtra(EXTRA_IS_VIDEOS_MODE, isVideosMode);
         courseDetail.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-        fragment.startActivityForResult(courseDetail, requestCode);
+        return courseDetail;
     }
 
     public void showCourseDiscussionAddPost(@NonNull Activity activity, @Nullable DiscussionTopic discussionTopic, @NonNull EnrolledCoursesResponse courseData) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/AuthenticatedWebView.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/AuthenticatedWebView.java
@@ -31,7 +31,7 @@ import org.edx.mobile.base.MainApplication;
 import org.edx.mobile.core.IEdxEnvironment;
 import org.edx.mobile.databinding.AuthenticatedWebviewBinding;
 import org.edx.mobile.event.CourseDashboardRefreshEvent;
-import org.edx.mobile.event.FileSelectionEvent;
+import org.edx.mobile.event.FileShareEvent;
 import org.edx.mobile.event.MainDashboardRefreshEvent;
 import org.edx.mobile.event.NetworkConnectivityChangeEvent;
 import org.edx.mobile.event.SessionIdRefreshEvent;
@@ -346,7 +346,7 @@ public class AuthenticatedWebView extends FrameLayout implements RefreshListener
 
     @Subscribe
     @SuppressWarnings("unused")
-    public void onEventMainThread(FileSelectionEvent event) {
+    public void onEventMainThread(FileShareEvent event) {
         if (webViewClient != null) {
             webViewClient.onFilesSelection(event.getFiles());
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/URLInterceptorWebViewClient.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/URLInterceptorWebViewClient.java
@@ -17,6 +17,7 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 
 import org.edx.mobile.core.EdxDefaultModule;
+import org.edx.mobile.event.FileSelectionEvent;
 import org.edx.mobile.http.HttpStatus;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.AjaxCallData;
@@ -28,6 +29,7 @@ import org.edx.mobile.util.ConfigUtil;
 import org.edx.mobile.util.FileUtil;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.util.links.WebViewLink;
+import org.greenrobot.eventbus.EventBus;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -152,7 +154,9 @@ public class URLInterceptorWebViewClient extends WebViewClient {
             @Override
             public boolean onShowFileChooser(WebView webView, ValueCallback<Uri[]> filePathCallback, FileChooserParams fileChooserParams) {
                 URLInterceptorWebViewClient.this.filePathCallback = filePathCallback;
-                FileUtil.chooseFiles(activity, fileChooserParams.getAcceptTypes());
+                EventBus.getDefault().post(new FileSelectionEvent(
+                        FileUtil.getChooseFilesIntent(fileChooserParams.getAcceptTypes())
+                ));
                 return true;
             }
         });

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/FullscreenLoaderDialogFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/FullscreenLoaderDialogFragment.kt
@@ -18,6 +18,7 @@ import org.edx.mobile.core.IEdxEnvironment
 import org.edx.mobile.databinding.DialogFullscreenLoaderBinding
 import org.edx.mobile.event.IAPFlowEvent
 import org.edx.mobile.exception.ErrorMessage
+import org.edx.mobile.extenstion.serializable
 import org.edx.mobile.model.iap.IAPFlowData
 import org.edx.mobile.module.analytics.Analytics
 import org.edx.mobile.module.analytics.InAppPurchasesAnalytics
@@ -72,7 +73,7 @@ class FullscreenLoaderDialogFragment : DialogFragment() {
 
     override fun onViewCreated(view: View, args: Bundle?) {
         super.onViewCreated(view, args)
-        iapFlowData = arguments?.getSerializable(KEY_IAP_DATA) as IAPFlowData?
+        iapFlowData = arguments?.serializable(KEY_IAP_DATA)
         loaderStartTime = arguments?.getLong(LOADER_START_TIME, Calendar.getInstance().timeInMillis)
             ?: Calendar.getInstance().timeInMillis
         intiViews()

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project is meant to be built using Android Studio. It can also be built fro
 
         git clone https://github.com/openedx/edx-app-android
 
-2. Setup the Android Studio. The latest tested Android Studio version is v3.3.2, you can download it from [the previous versions archive](https://developer.android.com/studio/archive). (You can find further details to run the project on the said version of Android Studio on this [PR](https://github.com/openedx/edx-app-android/pull/1264).
+2. Setup the Android Studio. The latest tested Android Studio version is Flamingo | 2022.2.1 Patch 2, you can download it from [the previous versions archive](https://developer.android.com/studio/archive).
 
 3. Open Android Studio and choose **Open an Existing Android Studio Project**
 
@@ -74,7 +74,7 @@ There are 3 Build Variants in this project:
 
 - **prodDebug**: Uses prod flavor for debug builds.
 - **prodDebuggable**: Uses prod flavor for debug builds with debugging enabled.
-- **prodRelease**: Uses prod flavor for release builds that'll work on devices with Android 4.4.x (KitKat) and above.
+- **prodRelease**: Uses prod flavor for release builds that'll work on devices with Android 5.0.x (Lollipop) and above.
 
 Building For Release
 --------------------
@@ -135,19 +135,6 @@ We're working on making it easier for Open edX installations to apply customizat
 
 Frequently Asked Questions
 ==========================
-**Q:** I see an error that mentions "Unsupported major.minor version 51.0". How do I fix this?
-
-**A:** Our build system requires Java 7 or later. If you see this error, install Java 7 or later.
-
-	 You will also need to specify the new JDK version in Android Studio. Refer to this Stack Overflow entry for help doing so:
-
-	 http://stackoverflow.com/questions/30631286/how-to-specify-the-jdk-version-in-android-studio
-
-**Q:** After I upgraded to Android Studio v2.3, I've been facing alot of issues while compiling/building the project. How do I fix this?
-
-**A:** We recently upgraded our project to support Android Studio v2.3.x and below. After the upgrade changes done in [PR #938](https://github.com/openedx/edx-app-android/pull/938), we too faced some issues.
-The fixes for the common issues can be seen in the [Issues section](https://github.com/openedx/edx-app-android/issues) of this GitHub project. The most common and helpful issue with the fixes is [Issue #976](https://github.com/openedx/edx-app-android/issues/976).
-
 **Q:** I want to use Firebase in my project, where do I place my [google-services.json](https://developers.google.com/android/guides/google-services-plugin#adding_the_json_file) file?
 
 **A:** You don’t need to place the [google-services.json](https://developers.google.com/android/guides/google-services-plugin#adding_the_json_file) into the project, we are generating it through gradle script ([AndroidHelper.gradle](https://github.com/openedx/edx-app-android/blob/master/OpenEdXMobile/gradle_scripts/AndroidHelper.gradle#L15)) that picks keys and values required in the [google-services.json](https://developers.google.com/android/guides/google-services-plugin#adding_the_json_file) file from the [app's configuration file](https://github.com/openedx/edx-app-android/blob/master/OpenEdXMobile/default_config/config.yaml). For configuration details [see](https://openedx.atlassian.net/wiki/spaces/LEARNER/pages/48792067/App+Configuration+Flags)

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
         classpath "com.google.firebase:perf-plugin:1.4.2"  // Performance Monitoring plugin
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
         // Firebase Crashlytics Gradle plugin.
-        classpath "com.google.firebase:firebase-crashlytics-gradle:2.9.6"
+        classpath "com.google.firebase:firebase-crashlytics-gradle:2.9.7"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
         classpath "org.jacoco:org.jacoco.core:0.8.8"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
         classpath "com.google.firebase:perf-plugin:1.4.2"  // Performance Monitoring plugin
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
         // Firebase Crashlytics Gradle plugin.
-        classpath "com.google.firebase:firebase-crashlytics-gradle:2.9.5"
+        classpath "com.google.firebase:firebase-crashlytics-gradle:2.9.6"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
         classpath "org.jacoco:org.jacoco.core:0.8.8"
     }

--- a/constants.gradle
+++ b/constants.gradle
@@ -13,7 +13,7 @@ project.ext {
     androidXCardviewVersion = "1.0.0"
     androidXAnnotationVersion = "1.6.0"
     androidXAppCompactVersion = "1.6.1"
-    kotlin_version_billing = "6.0.0"
+    kotlin_version_billing = "6.0.1"
     hilt_version = "2.44"
     gms_google_services = "4.3.15"
 


### PR DESCRIPTION
### Description

[LEARNER-9413](https://2u-internal.atlassian.net/browse/LEARNER-9413)

After migration to android-13 (SDK 33), and upgrading third-party libraries, the platform deprecates some methods and components, that need to be fixed.

The following needs to be updated

- `onActivityResult()`, `onBackPressed()`, `fragment.requestPermissions()`, `Html.fromHtml()` and `Linkify.ALL` with appropriate replacements.
- `getSerializableExtra(String!): Serializable?`, `getSerializable()`, `getParcelable()` and `get(String!): Any?` with appropriate replacements.