### PR TITLE
fix: App Crashing on background for IAP users

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/ContinuationExt.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/ContinuationExt.kt
@@ -1,0 +1,10 @@
+package org.edx.mobile.extenstion
+
+import kotlinx.coroutines.CancellableContinuation
+import kotlin.coroutines.resume
+
+fun CancellableContinuation<Boolean>.resumeIfActive(value: Boolean) {
+    if (isActive && isCompleted.not()) {
+        resume(value)
+    }
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/BillingProcessor.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/BillingProcessor.kt
@@ -24,13 +24,13 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import org.edx.mobile.extenstion.encodeToString
+import org.edx.mobile.extenstion.resumeIfActive
 import org.edx.mobile.logger.Logger
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 /**
  * The BillingProcessor implements all billing functionality for application.
@@ -69,14 +69,14 @@ class BillingProcessor @Inject constructor(
     }
 
     private suspend fun connect(): Boolean {
-        return suspendCoroutine { continuation ->
+        return suspendCancellableCoroutine { continuation ->
             billingClientStateListener = object : BillingClientStateListener {
                 override fun onBillingSetupFinished(billingResult: BillingResult) {
                     logger.debug("BillingSetupFinished -> $billingResult")
                     if (billingResult.responseCode == BillingResponseCode.OK) {
-                        continuation.resume(true)
+                        continuation.resumeIfActive(true)
                     } else {
-                        continuation.resume(false)
+                        continuation.resumeIfActive(false)
                     }
                 }
 
@@ -89,7 +89,7 @@ class BillingProcessor @Inject constructor(
                         connectionTryCount++
                         retryBillingServiceConnectionWithExponentialBackoff()
                     }
-                    continuation.resume(false)
+                    continuation.resumeIfActive(false)
                 }
             }
             billingClient.startConnection(billingClientStateListener)

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
@@ -469,7 +469,8 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
     }
 
     private void updateUIForOrientation() {
-        if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE && selectedUnit.isVideoBlock()) {
+        if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE &&
+                selectedUnit != null && selectedUnit.isVideoBlock()) {
             getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
             setActionBarVisible(false);
             findViewById(R.id.course_unit_nav_bar).setVisibility(View.GONE);


### PR DESCRIPTION
fixes: LEARNER-9527

### Description

[LEARNER-9527](https://2u-internal.atlassian.net/browse/LEARNER-9527)

- Fix app Crashing in the background for IAP users
- Use `CancellableContinuation` instated of `Continuation`.
- Resume `continuation` with results if active and not completed.
- Fix Issue NullPointerException on CourseComponent#isVideoBlock() for `CourseUnitNavigationActivity`

#### Steps to reproduce the crash.
- Open the app with IAP enabled.
- Force stop the Google play store app.
- edx App leads to the crash.