### PR TITLE
feat: Improve scrolling experience on Discover title

### DIFF
--- a/OpenEdXMobile/AndroidManifest.xml
+++ b/OpenEdXMobile/AndroidManifest.xml
@@ -187,8 +187,7 @@
 
         <activity
             android:name=".view.DiscoveryActivity"
-            android:label="@string/label_discover"
-            android:theme="@style/AppTheme.NoActionBar.TranslucentStatusBar" />
+            android:theme="@style/AppTheme.NoActionBar" />
 
         <activity
             android:name="org.edx.mobile.view.CertificateActivity"

--- a/OpenEdXMobile/res/layout/fragment_webview_discovery.xml
+++ b/OpenEdXMobile/res/layout/fragment_webview_discovery.xml
@@ -9,13 +9,12 @@
     <include
         android:id="@+id/toolbar"
         layout="@layout/collapsible_toolbar_layout"
-        android:visibility="gone" />
+        android:visibility="invisible" />
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipe_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+        android:layout_height="match_parent">
 
         <FrameLayout
             android:id="@+id/content_error_root"

--- a/OpenEdXMobile/res/values/strings_2.xml
+++ b/OpenEdXMobile/res/values/strings_2.xml
@@ -82,4 +82,7 @@
     <string name="continue_with_social">Continue with %s</string>
     <!-- Message shown while user waits for response to a sign in request-->
     <string name="signing_in">Signing in</string>
+
+    <!-- Title of Discover screen -->
+    <string name="label_explore_the_catalog">Explore the catalog</string>
 </resources>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscoveryActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscoveryActivity.java
@@ -46,19 +46,16 @@ public class DiscoveryActivity extends BaseSingleFragmentActivity {
     }
 
     @Override
+    public void onResume() {
+        super.onResume();
+        AuthPanelUtils.configureAuthPanel(findViewById(R.id.auth_panel), environment);
+    }
+
+    @Override
     protected void configureActionBar() {
         ActionBar bar = getSupportActionBar();
         if (bar != null) {
             bar.hide();
-            bar.setDisplayShowHomeEnabled(false);
-            bar.setDisplayHomeAsUpEnabled(false);
-            bar.setIcon(android.R.color.transparent);
         }
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-        AuthPanelUtils.configureAuthPanel(findViewById(R.id.auth_panel), environment);
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscoveryActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscoveryActivity.java
@@ -9,6 +9,7 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBar;
 import androidx.fragment.app.Fragment;
 
 import org.edx.mobile.R;
@@ -41,18 +42,23 @@ public class DiscoveryActivity extends BaseSingleFragmentActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setTitle(R.string.label_discover);
         environment.getAnalyticsRegistry().trackScreenView(Analytics.Screens.FIND_COURSES);
+    }
+
+    @Override
+    protected void configureActionBar() {
+        ActionBar bar = getSupportActionBar();
+        if (bar != null) {
+            bar.hide();
+            bar.setDisplayShowHomeEnabled(false);
+            bar.setDisplayHomeAsUpEnabled(false);
+            bar.setIcon(android.R.color.transparent);
+        }
     }
 
     @Override
     public void onResume() {
         super.onResume();
         AuthPanelUtils.configureAuthPanel(findViewById(R.id.auth_panel), environment);
-    }
-
-    @Override
-    public void setTitle(int titleId) {
-        setTitle(getResources().getString(titleId));
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/WebViewDiscoverFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/WebViewDiscoverFragment.java
@@ -2,6 +2,7 @@ package org.edx.mobile.view;
 
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.util.TypedValue;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -22,7 +23,6 @@ import org.edx.mobile.http.notifications.FullScreenErrorNotification;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.util.UiUtils;
 import org.edx.mobile.util.UrlUtil;
-import org.edx.mobile.util.ViewAnimationUtil;
 import org.edx.mobile.util.links.DefaultActionListener;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
@@ -82,29 +82,22 @@ public class WebViewDiscoverFragment extends BaseWebViewFragment {
     }
 
     private void initTitle() {
-        Bundle args = getArguments();
-        if (args != null && !TextUtils.isEmpty(args.getString(Router.EXTRA_SCREEN_TITLE))) {
-            binding.toolbar.getRoot().setVisibility(View.VISIBLE);
-            binding.toolbar.tvTitle.setText(args.getString(Router.EXTRA_SCREEN_TITLE));
-            ToolbarExtKt.setTitleStateListener(binding.toolbar.appbar,
-                    binding.toolbar.collapsingToolbar,
-                    new CollapsingToolbarStatListener() {
-                        @Override
-                        public void onExpanded() {
-                            ViewAnimationUtil.animateTitleSize(
-                                    binding.toolbar.tvTitle,
-                                    getResources().getDimension(R.dimen.edx_x_large));
-                        }
+        binding.toolbar.tvTitle.setText(getString(R.string.label_explore_all_courses));
+        binding.toolbar.tvTitle.setTextSize(TypedValue.COMPLEX_UNIT_PX, getResources().getDimension(R.dimen.edx_large));
 
-                        @Override
-                        public void onCollapsed() {
-                            ViewAnimationUtil.animateTitleSize(binding.toolbar.tvTitle,
-                                    getResources().getDimension(R.dimen.edx_large));
-                        }
-                    });
-        } else {
-            binding.toolbar.getRoot().setVisibility(View.GONE);
-        }
+        ToolbarExtKt.setTitleStateListener(binding.toolbar.appbar,
+                binding.toolbar.collapsingToolbar,
+                new CollapsingToolbarStatListener() {
+                    @Override
+                    public void onExpanded() {
+                        binding.toolbar.getRoot().setVisibility(View.INVISIBLE);
+                    }
+
+                    @Override
+                    public void onCollapsed() {
+                        binding.toolbar.getRoot().setVisibility(View.VISIBLE);
+                    }
+                });
     }
 
     public void setWebViewActionListener() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/WebViewDiscoverFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/WebViewDiscoverFragment.java
@@ -82,7 +82,7 @@ public class WebViewDiscoverFragment extends BaseWebViewFragment {
     }
 
     private void initTitle() {
-        binding.toolbar.tvTitle.setText(getString(R.string.label_explore_all_courses));
+        binding.toolbar.tvTitle.setText(getString(R.string.label_explore_the_catalog));
         binding.toolbar.tvTitle.setTextSize(TypedValue.COMPLEX_UNIT_PX, getResources().getDimension(R.dimen.edx_large));
 
         ToolbarExtKt.setTitleStateListener(binding.toolbar.appbar,


### PR DESCRIPTION
### Description

[LEARNER-9514](https://2u-internal.atlassian.net/browse/LEARNER-9514)

- Enhance the Scrolling Experience for the Discover Section
- Renamed the title from `Discover` to `Explore the Catalog`
- Defaulted the title to be hidden in favour of the web view's internal title
- The title will only be displayed upon scrolling
- Ensured consistency between the discovery experience for both guest users and logged-in users
