### PR TITLE
feat: Update Discover Course pages by removing course path

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/UrlUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/UrlUtil.java
@@ -5,7 +5,6 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 
 import org.edx.mobile.logger.Logger;
-import org.edx.mobile.util.links.WebViewLink;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -64,11 +63,6 @@ public class UrlUtil {
         for (String name : paramNames) {
             String value = uri.getQueryParameter(name);
             if (value != null) {
-                if (name.equals(WebViewLink.Param.PATH_ID) &&
-                        value.startsWith(WebViewLink.PATH_ID_COURSE_PREFIX)) {
-                    // Our config already has this prefix in the URI, so we need to get rid of it here in the param's value
-                    value = value.substring(WebViewLink.PATH_ID_COURSE_PREFIX.length()).trim();
-                }
                 paramsMap.put(name, value);
             }
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/links/WebViewLink.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/links/WebViewLink.java
@@ -14,7 +14,6 @@ import java.util.Map;
  */
 public class WebViewLink {
     public static final String SCHEME = "edxapp";
-    public static final String PATH_ID_COURSE_PREFIX = "course/";
 
     public enum Authority {
         COURSE_INFO("course_info"),

--- a/OpenEdXMobile/src/test/java/org/edx/mobile/test/WebViewLinkTest.java
+++ b/OpenEdXMobile/src/test/java/org/edx/mobile/test/WebViewLinkTest.java
@@ -28,21 +28,6 @@ public class WebViewLinkTest extends BaseTestCase {
         assertEquals(emailOptIn, Boolean.valueOf(link.params.get(WebViewLink.Param.EMAIL_OPT)));
     }
 
-    @Test
-    public void testWebViewLinkParsesCourseIdAndRemovesCoursePrefix() {
-        final String courseId = "cosmology-anux-anu-astro4x";
-        final Uri uri = new Uri.Builder()
-                .scheme(WebViewLink.SCHEME)
-                .authority(WebViewLink.Authority.COURSE_INFO.getKey())
-                .appendQueryParameter(WebViewLink.Param.PATH_ID,
-                        WebViewLink.PATH_ID_COURSE_PREFIX + courseId)
-                .build();
-        final WebViewLink link = WebViewLink.parse(uri.toString());
-        assertNotNull(link);
-        assertNotNull(link.params);
-        assertEquals(courseId, link.params.get(WebViewLink.Param.PATH_ID));
-    }
-
     /**
      * Tests our workaround for edx.org failing to encode plus signs in the course_id parameter
      * See https://openedx.atlassian.net/browse/MA-1901


### PR DESCRIPTION
### Description

[LEARNER-9544](https://2u-internal.atlassian.net/browse/LEARNER-9544)

- Update the course detail template through changes made in the config repository.
- Remove the relevant code associated with the course path.

### Notes
- Remove the `course/` path segment from the Course Detail Template

### Testing
- [ ] Courses on Discovery should work fine
- [ ] Course navigation and about pages should work fine