### PR TITLE
fix: Deep links to component navigation

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseHomeTabFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseHomeTabFragment.kt
@@ -19,7 +19,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.edx.mobile.R
 import org.edx.mobile.base.BaseFragmentActivity
 import org.edx.mobile.databinding.FragmentCourseHomeBinding
-import org.edx.mobile.deeplink.DeepLink
+import org.edx.mobile.deeplink.Screen
 import org.edx.mobile.deeplink.ScreenDef
 import org.edx.mobile.event.CourseDashboardRefreshEvent
 import org.edx.mobile.event.CourseOutlineRefreshEvent
@@ -28,6 +28,7 @@ import org.edx.mobile.event.MediaStatusChangeEvent
 import org.edx.mobile.event.NetworkConnectivityChangeEvent
 import org.edx.mobile.event.RefreshCourseDashboardEvent
 import org.edx.mobile.exception.CourseContentNotValidException
+import org.edx.mobile.extenstion.isNotNullOrEmpty
 import org.edx.mobile.extenstion.parcelable
 import org.edx.mobile.extenstion.serializableOrThrow
 import org.edx.mobile.extenstion.setVisibility
@@ -114,7 +115,7 @@ class CourseHomeTabFragment : OfflineSupportBaseFragment(), CourseHomeAdapter.On
                 this.serializableOrThrow(Router.EXTRA_COURSE_DATA) as EnrolledCoursesResponse
             courseUpgradeData = this.parcelable(Router.EXTRA_COURSE_UPGRADE_DATA)
             courseComponentId = this.getString(Router.EXTRA_COURSE_COMPONENT_ID)
-            screenName = this.getString(DeepLink.Keys.SCREEN_NAME)
+            screenName = this.getString(Router.EXTRA_SCREEN_NAME)
         } ?: run {
             throw IllegalStateException("No arguments available")
         }
@@ -257,6 +258,23 @@ class CourseHomeTabFragment : OfflineSupportBaseFragment(), CourseHomeAdapter.On
         }
         adapter.submitList(sectionList)
         updateListUI()
+        detectDeepLinking()
+    }
+
+    private fun detectDeepLinking() {
+        if (Screen.COURSE_COMPONENT.equals(screenName, true)
+            && courseComponentId.isNotNullOrEmpty()
+        ) {
+            val courseUnitDetailIntent = environment.router.getCourseUnitDetailIntent(
+                requireActivity(),
+                courseData,
+                courseUpgradeData,
+                courseComponentId,
+                false
+            )
+            courseUnitDetailLauncher.launch(courseUnitDetailIntent)
+            screenName = null
+        }
     }
 
     override fun onSectionItemClick(

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsDashboardFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsDashboardFragment.kt
@@ -234,6 +234,9 @@ class CourseTabsDashboardFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        if (this::binding.isInitialized.not()) {
+            return
+        }
         handleTabSelection(requireArguments())
 
         if (EventBus.getDefault().isRegistered(this).not())
@@ -442,7 +445,9 @@ class CourseTabsDashboardFragment : BaseFragment() {
 
     override fun onResume() {
         super.onResume()
-        courseDateViewModel.fetchCourseDates(courseData.courseId, true)
+        if (this::binding.isInitialized) {
+            courseDateViewModel.fetchCourseDates(courseData.courseId, true)
+        }
     }
 
     override fun onPause() {


### PR DESCRIPTION
### Description

[LEARNER-9634](https://2u-internal.atlassian.net/browse/LEARNER-9634)

The links were not functioning properly due to the absence of deep link handling on the Home Tab. Additionally, we implemented checks on `courseData` and `binding` to prevent them from triggering when the app starts from deep links.

_Creating PR on behalf of @farhan-arshad-dev_