### PR TITLE
Fix: Initialise button after adapter setup in UnitNavigationActivity

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/app_nav/CourseUnitNavigationActivity.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/app_nav/CourseUnitNavigationActivity.kt
@@ -177,8 +177,6 @@ class CourseUnitNavigationActivity : BaseFragmentActivity(), CourseUnitFragment.
             EventBus.getDefault().post(LogoutEvent())
             return
         }
-        binding.gotoPrev.setOnClickListener { navigatePreviousComponent() }
-        binding.gotoNext.setOnClickListener { navigateNextComponent() }
         onLoadData()
 
         if (subsection?.children.isNullOrEmpty()) {
@@ -195,6 +193,9 @@ class CourseUnitNavigationActivity : BaseFragmentActivity(), CourseUnitFragment.
         }
         binding.pager2.setVisibility(true)
         binding.stateLayout.root.setVisibility(false)
+
+        binding.gotoPrev.setOnClickListener { navigatePreviousComponent() }
+        binding.gotoNext.setOnClickListener { navigateNextComponent() }
     }
 
     public override fun onSaveInstanceState(outState: Bundle) {


### PR DESCRIPTION
### Description

[LEARNER-9653](https://2u-internal.atlassian.net/browse/LEARNER-9653)

- Initialise Navigation buttons after Pager Adapter initialisation on CourseUnitNavigation Activity