### PR TITLE
fix: vulnerable to cross-app script injection via crafted intent

### DIFF
--- a/OpenEdXMobile/AndroidManifest.xml
+++ b/OpenEdXMobile/AndroidManifest.xml
@@ -347,7 +347,7 @@
         <service
             android:name="org.edx.mobile.notifications.services.NotificationService"
             android:enabled="${fcmEnabled}"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT"/>
             </intent-filter>

--- a/OpenEdXMobile/AndroidManifest.xml
+++ b/OpenEdXMobile/AndroidManifest.xml
@@ -232,9 +232,10 @@
 
         <activity
             android:name=".view.dialog.WebViewActivity"
+            android:exported="false"
             android:screenOrientation="portrait"
-            android:exported="true"
-            android:theme="@style/AppTheme.NoActionBar.TranslucentStatusBar">
+            android:theme="@style/AppTheme.NoActionBar.TranslucentStatusBar"
+            tools:ignore="AppLinkUrlError">
             <intent-filter>
                 <category android:name="android.intent.category.DEFAULT" />
                 <action android:name="android.intent.action.VIEW" />
@@ -255,11 +256,11 @@
         <!--Google cast expanded controls activity-->
         <activity
             android:name="org.edx.mobile.googlecast.ExpandedControlsActivity"
+            android:exported="false"
             android:launchMode="singleTask"
-            android:theme="@style/Theme.CastVideosTheme"
-            android:exported="true">
+            android:theme="@style/Theme.CastVideosTheme">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
+                <action android:name="android.intent.action.MAIN" />
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
### Description

[LEARNER-9557](https://2u-internal.atlassian.net/browse/LEARNER-9557)

- Mitigated the vulnerability by disabling the ability to open custom-defined inner URIs through external sources. This was achieved by setting `android:exported="false"`.
- Setting `android:exported="false"` for the android component doesn't need to call outside from the app.

### Testing
- [ ] App should open a custom-defined URI or URL via browser OR crafted intent through other apps.