### PR TITLE
feat: Learner feedback collection from the mobile app

### DIFF
--- a/OpenEdXMobile/res/layout/fragment_account.xml
+++ b/OpenEdXMobile/res/layout/fragment_account.xml
@@ -351,11 +351,26 @@
                     style="@style/profile_field_description"
                     android:text="@string/description_submit_feedback" />
 
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btn_submit_feedback"
+                    style="@style/edX.Widget.ProfileActionBorderedButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/profile_view_button_height"
+                    android:layout_marginTop="@dimen/edx_half_margin"
+                    android:includeFontPadding="false"
+                    android:text="@string/label_submit_feedback_btn"
+                    app:backgroundTint="@null"
+                    app:icon="@drawable/ic_open_in_new"
+                    app:iconGravity="textEnd"
+                    app:iconSize="@dimen/ic_small"
+                    app:iconTint="@color/primaryBaseColor" />
+
                 <androidx.appcompat.widget.AppCompatButton
                     android:id="@+id/btn_email_support"
                     style="@style/edX.Widget.ProfileActionBorderedButton"
                     android:layout_marginTop="@dimen/edx_half_margin"
-                    android:text="@string/label_submit_feedback_btn" />
+                    android:text="@string/label_email_support_team_btn" />
             </LinearLayout>
 
             <LinearLayout

--- a/OpenEdXMobile/res/values-ar/profile_strings.xml
+++ b/OpenEdXMobile/res/values-ar/profile_strings.xml
@@ -18,7 +18,7 @@
     <!--  Description of Submit feedback Field  -->
     <string name="description_submit_feedback">هل تتطلع إلى تقديم طلب ميزة أو تزويدنا ببعض التعليقات على تطبيقنا؟</string>
     <!--  Label of Submit feedback Button  -->
-    <string name="label_submit_feedback_btn">أرسل بريدًا إلكترونيًا إلى فريق الدعم</string>
+    <string name="label_email_support_team_btn">أرسل بريدًا إلكترونيًا إلى فريق الدعم</string>
     <!--  Heading of Get Support Field  -->
     <string name="title_get_support">تلفى الدعم</string>
     <!--  Description of Get Support Field  -->

--- a/OpenEdXMobile/res/values-de-rDE/profile_strings.xml
+++ b/OpenEdXMobile/res/values-de-rDE/profile_strings.xml
@@ -18,7 +18,7 @@
     <!--  Description of Submit feedback Field  -->
     <string name="description_submit_feedback">Möchten Sie eine Funktionsanfrage stellen oder uns Feedback zu unserer App geben?</string>
     <!--  Label of Submit feedback Button  -->
-    <string name="label_submit_feedback_btn">E-Mail an das Support-Team senden</string>
+    <string name="label_email_support_team_btn">E-Mail an das Support-Team senden</string>
     <!--  Heading of Get Support Field  -->
     <string name="title_get_support">Unterstützung holen</string>
     <!--  Description of Get Support Field  -->

--- a/OpenEdXMobile/res/values-es/profile_strings.xml
+++ b/OpenEdXMobile/res/values-es/profile_strings.xml
@@ -18,7 +18,7 @@
     <!--  Description of Submit feedback Field  -->
     <string name="description_submit_feedback">¿Desea realizar una solicitud de función o darnos algún comentario sobre nuestra aplicación?</string>
     <!--  Label of Submit feedback Button  -->
-    <string name="label_submit_feedback_btn">Contactar al equipo de soporte</string>
+    <string name="label_email_support_team_btn">Contactar al equipo de soporte</string>
     <!--  Heading of Get Support Field  -->
     <string name="title_get_support">Obtener ayuda</string>
     <!--  Description of Get Support Field  -->

--- a/OpenEdXMobile/res/values-fr/profile_strings.xml
+++ b/OpenEdXMobile/res/values-fr/profile_strings.xml
@@ -18,7 +18,7 @@
     <!--  Description of Submit feedback Field  -->
     <string name="description_submit_feedback">Vous souhaitez faire une demande de fonctionnalité ou nous partager votre impression sur notre appli ?</string>
     <!--  Label of Submit feedback Button  -->
-    <string name="label_submit_feedback_btn">Envoyer un e-mail à l\'équipe support</string>
+    <string name="label_email_support_team_btn">Envoyer un e-mail à l\'équipe support</string>
     <!--  Heading of Get Support Field  -->
     <string name="title_get_support">Obtenir de l\'aide</string>
     <!--  Description of Get Support Field  -->

--- a/OpenEdXMobile/res/values-iw/profile_strings.xml
+++ b/OpenEdXMobile/res/values-iw/profile_strings.xml
@@ -18,7 +18,7 @@
     <!--  Description of Submit feedback Field  -->
     <string name="description_submit_feedback">מחפש להגיש בקשה או לתת לנו משוב על האפליקציה שלנו?</string>
     <!--  Label of Submit feedback Button  -->
-    <string name="label_submit_feedback_btn">שלח אימייל לצוות התמיכה</string>
+    <string name="label_email_support_team_btn">שלח אימייל לצוות התמיכה</string>
     <!--  Heading of Get Support Field  -->
     <string name="title_get_support">קבל תמיכה</string>
     <!--  Description of Get Support Field  -->

--- a/OpenEdXMobile/res/values-ja/profile_strings.xml
+++ b/OpenEdXMobile/res/values-ja/profile_strings.xml
@@ -18,7 +18,7 @@
     <!--  Description of Submit feedback Field  -->
     <string name="description_submit_feedback">機能リクエストまたはアプリのフィードバックを送信しませんか？</string>
     <!--  Label of Submit feedback Button  -->
-    <string name="label_submit_feedback_btn">サポートチームにメールを送信</string>
+    <string name="label_email_support_team_btn">サポートチームにメールを送信</string>
     <!--  Heading of Get Support Field  -->
     <string name="title_get_support">サポートを利用</string>
     <!--  Description of Get Support Field  -->

--- a/OpenEdXMobile/res/values-pt-rBR/profile_strings.xml
+++ b/OpenEdXMobile/res/values-pt-rBR/profile_strings.xml
@@ -18,7 +18,7 @@
     <!--  Description of Submit feedback Field  -->
     <string name="description_submit_feedback">Gostaria de solicitar alguma funcionalidade ou deixar uma opinião sobre nosso aplicativo?</string>
     <!--  Label of Submit feedback Button  -->
-    <string name="label_submit_feedback_btn">Enviar e-mail para a equipe de suporte</string>
+    <string name="label_email_support_team_btn">Enviar e-mail para a equipe de suporte</string>
     <!--  Heading of Get Support Field  -->
     <string name="title_get_support">Obter suporte</string>
     <!--  Description of Get Support Field  -->

--- a/OpenEdXMobile/res/values-tr/profile_strings.xml
+++ b/OpenEdXMobile/res/values-tr/profile_strings.xml
@@ -18,7 +18,7 @@
     <!--  Description of Submit feedback Field  -->
     <string name="description_submit_feedback">Bir özellik isteğinde bulunmak veya uygulamamıza dair geri bildirim vermek mi istiyorsunuz?</string>
     <!--  Label of Submit feedback Button  -->
-    <string name="label_submit_feedback_btn">Destek ekibine e-posta gönder</string>
+    <string name="label_email_support_team_btn">Destek ekibine e-posta gönder</string>
     <!--  Heading of Get Support Field  -->
     <string name="title_get_support">Destek alın</string>
     <!--  Description of Get Support Field  -->

--- a/OpenEdXMobile/res/values-vi/profile_strings.xml
+++ b/OpenEdXMobile/res/values-vi/profile_strings.xml
@@ -18,7 +18,7 @@
     <!--  Description of Submit feedback Field  -->
     <string name="description_submit_feedback">Bạn muốn yêu cầu một tính năng hoặc đưa ra một số phản hồi về ứng dụng của chúng tôi?</string>
     <!--  Label of Submit feedback Button  -->
-    <string name="label_submit_feedback_btn">Gửi email cho nhóm hỗ trợ</string>
+    <string name="label_email_support_team_btn">Gửi email cho nhóm hỗ trợ</string>
     <!--  Heading of Get Support Field  -->
     <string name="title_get_support">Nhận hỗ trợ</string>
     <!--  Description of Get Support Field  -->

--- a/OpenEdXMobile/res/values-zh/profile_strings.xml
+++ b/OpenEdXMobile/res/values-zh/profile_strings.xml
@@ -18,7 +18,7 @@
     <!--  Description of Submit feedback Field  -->
     <string name="description_submit_feedback">希望对我们的应用程序提出功能请求或提供一些反馈？</string>
     <!--  Label of Submit feedback Button  -->
-    <string name="label_submit_feedback_btn">发email给支持服务团队</string>
+    <string name="label_email_support_team_btn">发email给支持服务团队</string>
     <!--  Heading of Get Support Field  -->
     <string name="title_get_support">获取支持</string>
     <!--  Description of Get Support Field  -->

--- a/OpenEdXMobile/res/values/profile_strings.xml
+++ b/OpenEdXMobile/res/values/profile_strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Profile Page -->
     <!-- Label for wifi only switch -->
     <string name="settings_wifi_top">Wifi only download</string>
@@ -17,8 +17,10 @@
     <string name="label_help">Help</string>
     <!--  Description of Submit feedback Field  -->
     <string name="description_submit_feedback">Looking to make a feature request or give us some feedback on our app?</string>
+    <!--  Label of Email to Support Team Button  -->
+    <string name="label_email_support_team_btn">Email the support team</string>
     <!--  Label of Submit feedback Button  -->
-    <string name="label_submit_feedback_btn">Email the support team</string>
+    <string name="label_submit_feedback_btn" tools:ignore="MissingTranslation">Submit feedback</string>
     <!--  Heading of Get Support Field  -->
     <string name="title_get_support">Get support</string>
     <!--  Description of Get Support Field  -->

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/AppConfig.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/AppConfig.kt
@@ -13,7 +13,10 @@ data class AppConfig(
     val isValuePropEnabled: Boolean = false,
 
     @SerializedName("iap_config")
-    val iapConfig: IAPConfig = IAPConfig()
+    val iapConfig: IAPConfig = IAPConfig(),
+
+    @SerializedName("feedback_form_url")
+    val feedbackFormUrl: String? = null
 
 ) : Serializable
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
@@ -900,6 +900,8 @@ public interface Analytics {
         String PRIVACY_POLICY_CLICKED = "edx.bi.app.profile.privacy_policy.clicked";
         String COOKIE_POLICY_CLICKED = "edx.bi.app.profile.cookie_policy.clicked";
         String DO_NOT_SELL_DATA_CLICKED = "edx.bi.app.profile.do_not_sell_data.clicked";
+        String SUBMIT_FEEDBACK_CLICKED = "edx.bi.app.profile.submit_feedback.clicked";
+
         // Video Download Quality
         String PROFILE_VIDEO_DOWNLOAD_QUALITY_CLICKED = "edx.bi.app.profile.video_download_quality.clicked";
         String COURSE_VIDEOS_VIDEO_DOWNLOAD_QUALITY_CLICKED = "edx.bi.app.course_videos.video_download_quality.clicked";
@@ -1120,6 +1122,8 @@ public interface Analytics {
         String PRIVACY_POLICY_CLICKED = "Privacy Policy Clicked";
         String COOKIE_POLICY_CLICKED = "Cookie Policy Clicked";
         String DO_NOT_SELL_DATA_CLICKED = "Do Not Sell Data Clicked";
+        String SUBMIT_FEEDBACK_CLICKED = "Submit feedback clicked";
+
         // Video Download Quality
         String PROFILE_VIDEO_DOWNLOAD_QUALITY_CLICKED = "Profile: Video Download Quality Clicked";
         String COURSE_VIDEOS_VIDEO_DOWNLOAD_QUALITY_CLICKED = "Course Videos: Video Download Quality Clicked";

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/FeaturesPrefs.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/FeaturesPrefs.kt
@@ -24,6 +24,9 @@ class FeaturesPrefs @Inject constructor(
     val isValuePropEnabled
         get() = appConfig.isValuePropEnabled
 
+    val feedbackFormUrl
+        get() = appConfig.feedbackFormUrl
+
     val isIAPEnabled
         get() = iapConfig.isEnabled &&
                 iapConfig.disableVersions.contains(BuildConfig.VERSION_NAME).not()

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/AccountFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/AccountFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.webkit.URLUtil
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.bumptech.glide.Glide
@@ -34,6 +35,7 @@ import org.edx.mobile.model.user.Account
 import org.edx.mobile.model.video.VideoQuality
 import org.edx.mobile.module.analytics.Analytics
 import org.edx.mobile.module.analytics.InAppPurchasesAnalytics
+import org.edx.mobile.module.prefs.FeaturesPrefs
 import org.edx.mobile.module.prefs.LoginPrefs
 import org.edx.mobile.module.prefs.UserPrefs
 import org.edx.mobile.user.UserAPI.AccountDataUpdatedCallback
@@ -73,6 +75,9 @@ class AccountFragment : BaseFragment() {
 
     @Inject
     lateinit var environment: IEdxEnvironment
+
+    @Inject
+    lateinit var featuresPrefs: FeaturesPrefs
 
     @Inject
     lateinit var loginPrefs: LoginPrefs
@@ -297,6 +302,18 @@ class AccountFragment : BaseFragment() {
     }
 
     private fun initHelpFields() {
+        if (URLUtil.isValidUrl(featuresPrefs.feedbackFormUrl)) {
+            binding.btnSubmitFeedback.setVisibility(true)
+            binding.btnSubmitFeedback.setOnClickListener {
+                BrowserUtil.open(requireActivity(), featuresPrefs.feedbackFormUrl, false)
+                trackEvent(
+                    Analytics.Events.SUBMIT_FEEDBACK_CLICKED,
+                    Analytics.Values.SUBMIT_FEEDBACK_CLICKED
+                )
+            }
+        } else {
+            binding.btnSubmitFeedback.setVisibility(false)
+        }
         if (!config.feedbackEmailAddress.isNullOrBlank() || !config.faqUrl.isNullOrBlank()) {
             binding.tvHelp.visibility = View.VISIBLE
             if (!config.feedbackEmailAddress.isNullOrBlank()) {


### PR DESCRIPTION
### Description

[LEARNER-9834](https://2u-internal.atlassian.net/browse/LEARNER-9834)

- Learner feedback collection from the mobile app.
- A "Submit Feedback" button should be added to the help section of the profile screen above the “Email the support team” in the edX mobile app.
- The button should feature an icon indicating that it leads to an external link.
- When the "Submit Feedback" button is tapped, it should open an external link, launching a Google Form in the user's default browser.
- Trigger event on Submit Feedback button clicked.

**Config was added in Endpoint**: 
      `/api/mobile/{api_version}/users/{username}/course_enrollments`
