### PR TITLE
feat: Consumable In-App Purchases

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/exception/ErrorMessage.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/exception/ErrorMessage.kt
@@ -24,6 +24,7 @@ data class ErrorMessage(
         const val COURSE_REFRESH_CODE = 0x205
         const val PRICE_CODE = 0x206
         const val NO_SKU_CODE = 0x207
+        const val CONSUME_CODE = 0x208
     }
 
     private fun isPreUpgradeErrorType(): Boolean =
@@ -56,6 +57,7 @@ data class ErrorMessage(
     fun canRetry(): Boolean {
         return requestType == PRICE_CODE ||
                 requestType == EXECUTE_ORDER_CODE ||
+                requestType == CONSUME_CODE ||
                 requestType == COURSE_REFRESH_CODE
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/EncryptionExt.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/extenstion/EncryptionExt.kt
@@ -6,9 +6,21 @@ fun Long.encodeToString(): String {
     return Base64.encodeToString(this.toString().toByteArray(), Base64.DEFAULT)
 }
 
+fun String.encodeToString(): String {
+    return Base64.encodeToString(this.toByteArray(), Base64.DEFAULT)
+}
+
 fun String.decodeToLong(): Long? {
     return try {
         Base64.decode(this, Base64.DEFAULT).toString(Charsets.UTF_8).toLong()
+    } catch (ex: Exception) {
+        null
+    }
+}
+
+fun String.decodeToString(): String? {
+    return try {
+        Base64.decode(this, Base64.DEFAULT).toString(Charsets.UTF_8)
     } catch (ex: Exception) {
         null
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/BillingProcessor.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/BillingProcessor.kt
@@ -15,6 +15,7 @@ import com.android.billingclient.api.ConsumeParams
 import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.ProductDetailsResult
 import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.Purchase.PurchaseState
 import com.android.billingclient.api.PurchasesUpdatedListener
 import com.android.billingclient.api.QueryProductDetailsParams
 import com.android.billingclient.api.QueryPurchasesParams
@@ -242,7 +243,7 @@ class BillingProcessor @Inject constructor(
             QueryPurchasesParams.newBuilder()
                 .setProductType(BillingClient.ProductType.INAPP)
                 .build()
-        ).purchasesList
+        ).purchasesList.filter { it.purchaseState == PurchaseState.PURCHASED }
     }
 
     suspend fun consumePurchase(purchaseToken: String): BillingResult {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/BillingProcessor.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/BillingProcessor.kt
@@ -11,6 +11,7 @@ import com.android.billingclient.api.BillingClientStateListener
 import com.android.billingclient.api.BillingFlowParams
 import com.android.billingclient.api.BillingFlowParams.ProductDetailsParams
 import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.ConsumeParams
 import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.ProductDetailsResult
 import com.android.billingclient.api.Purchase
@@ -18,6 +19,7 @@ import com.android.billingclient.api.PurchasesUpdatedListener
 import com.android.billingclient.api.QueryProductDetailsParams
 import com.android.billingclient.api.QueryPurchasesParams
 import com.android.billingclient.api.acknowledgePurchase
+import com.android.billingclient.api.consumePurchase
 import com.android.billingclient.api.queryProductDetails
 import com.android.billingclient.api.queryPurchasesAsync
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -26,10 +28,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import org.edx.mobile.extenstion.decodeToString
 import org.edx.mobile.extenstion.encodeToString
 import org.edx.mobile.extenstion.resumeIfActive
 import org.edx.mobile.injection.DataSourceDispatcher
 import org.edx.mobile.logger.Logger
+import org.edx.mobile.model.api.EnrolledCoursesResponse.ProductInfo
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -125,16 +129,20 @@ class BillingProcessor @Inject constructor(
      * Called to purchase the new product. Query the product details and launch the purchase flow.
      *
      * @param activity active activity to launch our billing flow from
-     * @param productId Product Id to be purchased
      * @param userId    User Id of the purchaser
+     * @param productInfo Course and Product info to purchase
      */
-    suspend fun purchaseItem(activity: Activity, productId: String, userId: Long) {
+    suspend fun purchaseItem(
+        activity: Activity,
+        userId: Long,
+        productInfo: ProductInfo,
+    ) {
         if (isReadyOrConnect()) {
-            val response = querySyncDetails(productId)
+            val response = querySyncDetails(productInfo.storeSku)
             logger.debug("Getting Purchases -> ${response.billingResult}")
 
             response.productDetailsList?.first()?.let {
-                launchBillingFlow(activity, it, userId)
+                launchBillingFlow(activity, it, userId, productInfo.courseSku)
             }
         } else {
             listener.onPurchaseCancel(BillingResponseCode.BILLING_UNAVAILABLE, "")
@@ -152,7 +160,8 @@ class BillingProcessor @Inject constructor(
     private fun launchBillingFlow(
         activity: Activity,
         productDetails: ProductDetails,
-        userId: Long
+        userId: Long,
+        courseSku: String,
     ) {
         val productDetailsParamsList = listOf(
             ProductDetailsParams.newBuilder()
@@ -163,6 +172,7 @@ class BillingProcessor @Inject constructor(
         val billingFlowParams = BillingFlowParams.newBuilder()
             .setProductDetailsParamsList(productDetailsParamsList)
             .setObfuscatedAccountId(userId.encodeToString())
+            .setObfuscatedProfileId(courseSku.encodeToString())
             .build()
 
         billingClient.launchBillingFlow(activity, billingFlowParams)
@@ -235,6 +245,17 @@ class BillingProcessor @Inject constructor(
         ).purchasesList
     }
 
+    suspend fun consumePurchase(purchaseToken: String): BillingResult {
+        isReadyOrConnect()
+        val result = billingClient.consumePurchase(
+            ConsumeParams
+                .newBuilder()
+                .setPurchaseToken(purchaseToken)
+                .build()
+        )
+        return result.billingResult
+    }
+
     companion object {
         private val TAG = BillingProcessor::class.java.simpleName
         private const val RECONNECT_TIMER_START_MILLISECONDS = 1L * 1000L
@@ -251,3 +272,7 @@ class BillingProcessor @Inject constructor(
 
 fun ProductDetails.OneTimePurchaseOfferDetails.getPriceAmount(): Double =
     this.priceAmountMicros.toDouble().div(BillingProcessor.MICROS_TO_UNIT)
+
+fun Purchase.getCourseSku(): String? {
+    return this.accountIdentifiers?.obfuscatedProfileId?.decodeToString()
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/AppConfig.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/AppConfig.kt
@@ -31,6 +31,9 @@ data class IAPConfig(
     @SerializedName("experiment_enabled")
     val isExperimentEnabled: Boolean = false,
 
+    @SerializedName("android_product_prefix")
+    val productPrefix: String = "",
+
     @SerializedName("android_disabled_versions")
     val disableVersions: List<String> = listOf()
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/CourseMode.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/CourseMode.kt
@@ -2,6 +2,7 @@ package org.edx.mobile.model.api
 
 import com.google.gson.annotations.SerializedName
 import java.io.Serializable
+import kotlin.math.ceil
 
 data class CourseMode(
     @SerializedName("slug")
@@ -12,4 +13,20 @@ data class CourseMode(
 
     @SerializedName("android_sku")
     val androidSku: String?,
-) : Serializable
+
+    @SerializedName("min_price")
+    val price: Double?,
+
+    var storeSku: String?,
+) : Serializable {
+
+    fun setStoreProductSku(storeProductPrefix: String) {
+        val ceilPrice = price
+            ?.let { ceil(it).toInt() }
+            ?.takeIf { it > 0 }
+
+        if (storeProductPrefix.isNotBlank() && ceilPrice != null) {
+            storeSku = "$storeProductPrefix$ceilPrice"
+        }
+    }
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/EnrolledCoursesResponse.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/EnrolledCoursesResponse.kt
@@ -5,6 +5,7 @@ import com.google.gson.annotations.SerializedName
 import org.edx.mobile.interfaces.SectionItemInterface
 import org.edx.mobile.model.course.EnrollmentMode
 import org.edx.mobile.util.DateUtil
+import java.io.Serializable
 import java.util.Date
 
 data class EnrolledCoursesResponse(
@@ -39,11 +40,6 @@ data class EnrolledCoursesResponse(
     val isCertificateEarned: Boolean
         get() = certificateURL.isNullOrEmpty().not()
 
-    val courseSku: String?
-        get() = courseModes?.firstOrNull { item ->
-            EnrollmentMode.VERIFIED.name.equals(item.slug, ignoreCase = true)
-        }?.androidSku.takeUnless { it.isNullOrEmpty() }
-
     val isAuditMode: Boolean
         get() = EnrollmentMode.AUDIT.toString().equals(mode, ignoreCase = true)
 
@@ -58,6 +54,29 @@ data class EnrolledCoursesResponse(
                 courseModes?.find {
                     EnrollmentMode.VERIFIED.toString().equals(it.slug, ignoreCase = true)
                 } != null
+
+    val productInfo: ProductInfo?
+        get() = courseSku?.let { courseSku ->
+            storeSku?.let { storeSku ->
+                ProductInfo(courseSku, storeSku)
+            }
+        }
+
+    private val courseSku: String?
+        get() = courseModes?.firstOrNull { item ->
+            EnrollmentMode.VERIFIED.name.equals(item.slug, ignoreCase = true)
+        }?.androidSku.takeUnless { it.isNullOrEmpty() }
+
+    private val storeSku: String?
+        get() = courseModes?.firstOrNull { item ->
+            EnrollmentMode.VERIFIED.name.equals(item.slug, ignoreCase = true)
+        }?.storeSku
+
+    fun setStoreSku(storeProductPrefix: String) {
+        courseModes?.forEach {
+            it.setStoreProductSku(storeProductPrefix)
+        }
+    }
 
     override fun isChapter(): Boolean {
         return false
@@ -82,6 +101,11 @@ data class EnrolledCoursesResponse(
     override fun isDownload(): Boolean {
         return false
     }
+
+    data class ProductInfo(
+        val courseSku: String,
+        val storeSku: String,
+    ) : Serializable
 }
 
 /**

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/EnrollmentResponse.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/EnrollmentResponse.kt
@@ -7,6 +7,7 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
+import org.edx.mobile.extenstion.isNotNullOrEmpty
 import org.edx.mobile.logger.Logger
 import org.edx.mobile.model.iap.IAPFlowData
 import java.io.Serializable
@@ -59,6 +60,12 @@ data class EnrollmentResponse(
                         AppConfig::class.java
                     )
 
+                    if (appConfig.iapConfig.productPrefix.isNotNullOrEmpty()) {
+                        enrolledCourses.forEach { courseData ->
+                            courseData.setStoreSku(appConfig.iapConfig.productPrefix)
+                        }
+                    }
+
                     EnrollmentResponse(appConfig, enrolledCourses)
                 }
             } catch (ex: Exception) {
@@ -76,12 +83,12 @@ data class EnrollmentResponse(
  */
 fun List<EnrolledCoursesResponse>.getAuditCourses(): List<IAPFlowData> {
     return this.filter {
-        it.isAuditMode && it.courseSku.isNullOrBlank().not()
+        it.isAuditMode && it.productInfo != null
     }.mapNotNull { course ->
-        course.courseSku?.let { sku ->
+        course.productInfo?.let { productInfo ->
             IAPFlowData(
                 courseId = course.courseId,
-                productId = sku,
+                productInfo = productInfo,
                 isCourseSelfPaced = course.course.isSelfPaced
             )
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/CourseComponent.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/CourseComponent.java
@@ -1,5 +1,7 @@
 package org.edx.mobile.model.course;
 
+import static org.edx.mobile.model.api.EnrolledCoursesResponse.ProductInfo;
+
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
@@ -43,7 +45,7 @@ public class CourseComponent implements IBlock, IPathNode {
     private String authorizationDenialMessage;
     private AuthorizationDenialReason authorizationDenialReason;
     private SpecialExamInfo specialExamInfo;
-    private String courseSku;
+    private ProductInfo productInfo;
 
     public CourseComponent() {
     }
@@ -69,7 +71,7 @@ public class CourseComponent implements IBlock, IPathNode {
         this.authorizationDenialMessage = other.authorizationDenialMessage;
         this.authorizationDenialReason = other.authorizationDenialReason;
         this.specialExamInfo = other.specialExamInfo;
-        this.courseSku = other.courseSku;
+        this.productInfo = other.productInfo;
     }
 
     /**
@@ -572,12 +574,12 @@ public class CourseComponent implements IBlock, IPathNode {
         return specialExamInfo;
     }
 
-    public String getCourseSku() {
-        return courseSku;
+    public ProductInfo getProductInfo() {
+        return productInfo;
     }
 
-    public void setCourseSku(String courseSku) {
-        this.courseSku = courseSku;
+    public void setProductInfo(ProductInfo productInfo) {
+        this.productInfo = productInfo;
     }
 
     public ArrayList<SectionRow> getSectionData() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/iap/IAPFlowData.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/iap/IAPFlowData.kt
@@ -1,12 +1,13 @@
 package org.edx.mobile.model.iap
 
+import org.edx.mobile.model.api.EnrolledCoursesResponse.ProductInfo
 import java.io.Serializable
 
 data class IAPFlowData(
     var flowType: IAPFlowType = IAPFlowType.USER_INITIATED,
     var courseId: String = "",
     var isCourseSelfPaced: Boolean = false,
-    var productId: String = "",
+    var productInfo: ProductInfo = ProductInfo("", ""),
     var basketId: Long = 0,
     var purchaseToken: String = "",
     var price: Double = 0.0,
@@ -17,7 +18,7 @@ data class IAPFlowData(
     fun clear() {
         courseId = ""
         isCourseSelfPaced = false
-        productId = ""
+        productInfo = ProductInfo("", "")
         basketId = 0
         price = 0.0
         currencyCode = ""

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/InAppPurchasesUtils.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/InAppPurchasesUtils.kt
@@ -4,6 +4,7 @@ import com.android.billingclient.api.Purchase
 import org.edx.mobile.R
 import org.edx.mobile.exception.ErrorMessage
 import org.edx.mobile.http.HttpStatus
+import org.edx.mobile.inapppurchases.getCourseSku
 import org.edx.mobile.model.iap.IAPFlowData
 
 object InAppPurchasesUtils {
@@ -20,7 +21,7 @@ object InAppPurchasesUtils {
     ): MutableList<IAPFlowData> {
         purchases.forEach { purchase ->
             auditCourses.find { course ->
-                purchase.products.first().equals(course.productId)
+                purchase.getCourseSku() == course.productInfo.courseSku
             }?.apply {
                 this.purchaseToken = purchase.purchaseToken
                 this.flowType = flowType

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/TextUtils.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/TextUtils.java
@@ -64,9 +64,7 @@ public class TextUtils {
      * @return App specific URI string.
      */
     public static String createAppUri(@NonNull String title, @NonNull String uri) {
-        final StringBuilder uriString = new StringBuilder(AppConstants.APP_URI_SCHEME);
-        uriString.append(title).append("?").append(PARAM_INTENT_FILE_LINK).append("=").append(uri);
-        return uriString.toString();
+        return AppConstants.APP_URI_SCHEME + title + "?" + PARAM_INTENT_FILE_LINK + "=" + uri;
     }
 
     /**
@@ -96,19 +94,19 @@ public class TextUtils {
 
         if (!android.text.TextUtils.isEmpty(eulaUri)) {
             eulaSpan.setSpan(new UrlSpanNoUnderline(TextUtils.createAppUri(
-                    context.getResources().getString(R.string.end_user_title), eulaUri)),
+                            context.getResources().getString(R.string.end_user_title), eulaUri)),
                     0, eula.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
 
         if (!android.text.TextUtils.isEmpty(tosUri)) {
             tosSpan.setSpan(new UrlSpanNoUnderline(TextUtils.createAppUri(
-                    context.getResources().getString(R.string.terms_of_service_title), tosUri)),
+                            context.getResources().getString(R.string.terms_of_service_title), tosUri)),
                     0, tos.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
 
         if (!android.text.TextUtils.isEmpty(privacyPolicyUri)) {
             privacyPolicySpan.setSpan(new UrlSpanNoUnderline(TextUtils.createAppUri(
-                    context.getResources().getString(R.string.privacy_policy_title), privacyPolicyUri)),
+                            context.getResources().getString(R.string.privacy_policy_title), privacyPolicyUri)),
                     0, privacyPolicy.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
 
@@ -214,6 +212,7 @@ public class TextUtils {
             case ErrorMessage.PAYMENT_SDK_CODE -> "payment";
             case ErrorMessage.PRICE_CODE -> "price";
             case ErrorMessage.NO_SKU_CODE -> "sku";
+            case ErrorMessage.CONSUME_CODE -> "consume";
             default -> "unhandledError";
         };
         body.append(String.format("%s", endpoint));

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/AccountFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/AccountFragment.kt
@@ -242,6 +242,8 @@ class AccountFragment : BaseFragment() {
                 retryListener = DialogInterface.OnClickListener { _, _ ->
                     if (errorMessage.requestType == ErrorMessage.EXECUTE_ORDER_CODE) {
                         iapViewModel.executeOrder()
+                    } else if (errorMessage.requestType == ErrorMessage.CONSUME_CODE) {
+                        iapViewModel.consumeOrderForFurtherPurchases(iapViewModel.iapFlowData)
                     } else if (HttpStatus.NOT_ACCEPTABLE == (errorMessage.throwable as InAppPurchasesException).httpErrorCode) {
                         showFullScreenLoader()
                     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.kt
@@ -78,7 +78,7 @@ class CourseUnitMobileNotSupportedFragment : CourseUnitFragment() {
     private fun showGradedContent() {
         unit?.let { unit ->
             val isSelfPaced = getBooleanArgument(Router.EXTRA_IS_SELF_PACED, false)
-            val isPurchaseEnabled = unit.courseSku.isNullOrEmpty().not() &&
+            val isPurchaseEnabled = unit.productInfo != null &&
                     environment.featuresPrefs.isIAPEnabledForUser(environment.loginPrefs.isOddUserId)
 
             binding.containerLayoutNotAvailable.root.setVisibility(false)
@@ -95,7 +95,7 @@ class CourseUnitMobileNotSupportedFragment : CourseUnitFragment() {
             environment.analyticsRegistry.trackValuePropMessageViewed(
                 unit.courseId,
                 Screens.COURSE_UNIT,
-                (unit.courseSku.isNullOrEmpty().not() && environment.featuresPrefs.isIAPEnabled),
+                (unit.productInfo != null && environment.featuresPrefs.isIAPEnabled),
                 experimentGroup,
                 unit.id
             )
@@ -112,7 +112,7 @@ class CourseUnitMobileNotSupportedFragment : CourseUnitFragment() {
                 // by adding the some delay fixed that issue for lower-end devices, and for the
                 // proper animation.
                 binding.layoutUpgradeBtn.shimmerViewContainer.postDelayed({
-                    iapViewModel.initializeProductPrice(unit.courseSku)
+                    iapViewModel.initializeProductPrice(unit.productInfo)
                 }, 1500)
                 binding.layoutUpgradeBtn.btnUpgrade.isEnabled = false
             } else {
@@ -175,7 +175,7 @@ class CourseUnitMobileNotSupportedFragment : CourseUnitFragment() {
             iapViewModel.purchaseItem(
                 requireActivity(),
                 environment.loginPrefs.userId,
-                unit?.courseSku
+                unit?.productInfo,
             )
         })
 
@@ -207,7 +207,7 @@ class CourseUnitMobileNotSupportedFragment : CourseUnitFragment() {
             retryListener = DialogInterface.OnClickListener { _, _ ->
                 when (errorMessage.requestType) {
                     ErrorMessage.PRICE_CODE -> {
-                        iapViewModel.initializeProductPrice(unit?.courseSku)
+                        iapViewModel.initializeProductPrice(unit?.productInfo)
                     }
                 }
             }
@@ -239,9 +239,9 @@ class CourseUnitMobileNotSupportedFragment : CourseUnitFragment() {
 
         binding.layoutUpgradeBtn.btnUpgrade.setOnClickListener {
             iapAnalytics.trackIAPEvent(Events.IAP_UPGRADE_NOW_CLICKED)
-            unit?.courseSku?.let { productId ->
+            unit?.productInfo?.let { productInfo ->
                 iapViewModel.startPurchaseFlow(
-                    productId,
+                    productInfo,
                     productDetails.getPriceAmount(),
                     productDetails.priceCurrencyCode,
                 )

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.kt
@@ -107,7 +107,7 @@ class MyCoursesListFragment : OfflineSupportBaseFragment(), RefreshListener {
                     CourseModalDialogFragment.newInstance(
                         Analytics.Screens.COURSE_ENROLLMENT,
                         model.courseId,
-                        model.courseSku,
+                        model.productInfo,
                         model.course.name,
                         model.course.isSelfPaced
                     ).show(childFragmentManager, CourseModalDialogFragment.TAG)
@@ -246,6 +246,8 @@ class MyCoursesListFragment : OfflineSupportBaseFragment(), RefreshListener {
                 retryListener = DialogInterface.OnClickListener { _, _ ->
                     if (errorMessage.requestType == ErrorMessage.EXECUTE_ORDER_CODE) {
                         iapViewModel.executeOrder()
+                    } else if (errorMessage.requestType == ErrorMessage.CONSUME_CODE) {
+                        iapViewModel.consumeOrderForFurtherPurchases(iapViewModel.iapFlowData)
                     } else if (errorMessage.requestType == ErrorMessage.COURSE_REFRESH_CODE) {
                         courseViewModel.fetchEnrolledCourses(
                             type = CoursesRequestType.LIVE,

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseUnitPagerAdapter.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseUnitPagerAdapter.kt
@@ -54,14 +54,14 @@ class CourseUnitPagerAdapter(
             is HtmlBlockModel -> HtmlBlockModel(unit)
             else -> CourseComponent(unit)
         }
-        minifiedUnit.courseSku = courseData.courseSku
+        minifiedUnit.productInfo = courseData.productInfo
 
         val unitFragment = when {
             minifiedUnit.authorizationDenialReason == AuthorizationDenialReason.FEATURE_BASED_ENROLLMENTS -> {
                 if (courseUpgradeData == null) {
                     CourseUnitMobileNotSupportedFragment.newInstance(minifiedUnit, courseData)
                 } else {
-                    minifiedUnit.courseSku = courseData.courseSku
+                    minifiedUnit.productInfo = courseData.productInfo
                     LockedCourseUnitFragment.newInstance(
                         minifiedUnit,
                         courseData,

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/FullscreenLoaderDialogFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/FullscreenLoaderDialogFragment.kt
@@ -107,10 +107,18 @@ class FullscreenLoaderDialogFragment : DialogFragment() {
                     fragment = this@FullscreenLoaderDialogFragment,
                     errorMessage = errorMessage,
                     retryListener = { _, _ ->
-                        if (errorMessage.requestType == ErrorMessage.EXECUTE_ORDER_CODE) {
-                            iapViewModel.executeOrder(iapFlowData)
-                        } else {
-                            purchaseFlowComplete()
+                        when (errorMessage.requestType) {
+                            ErrorMessage.EXECUTE_ORDER_CODE -> {
+                                iapViewModel.executeOrder(iapFlowData)
+                            }
+
+                            ErrorMessage.CONSUME_CODE -> {
+                                iapViewModel.consumeOrderForFurtherPurchases(iapViewModel.iapFlowData)
+                            }
+
+                            else -> {
+                                purchaseFlowComplete()
+                            }
                         }
                     },
                     cancelListener = { _, _ ->


### PR DESCRIPTION
### Description

[LEARNER-9818](https://2u-internal.atlassian.net/browse/LEARNER-9818) | [LEARNER-9878](https://2u-internal.atlassian.net/browse/LEARNER-9878)

### Remote Config Changes for Store SKU

The `storeSku` will be the combination of `prodcut_prefix` value from Remote Config and `min_price` from course modes in enrolments API.

### Implementation

1. Fetch the `courseSku` and `storeSku` using the enrollments API.

2. Utilize the `courseSku` for the `add_to_basket` and `checkout` APIs.

3. Handling Play Console purchases:
   - Store `courseSku` within the purchase as a payload using `obfuscatedProfileId` ([ref](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setObfuscatedProfileId(java.lang.String))).
   - Utilize the `storeSku` for the purchase.

4. After a successful purchase:
   - Retrieve the `courseSku` from `obfuscatedProfileId`.
   - Extract `storeSku` from the product ID.
   - Implement a similar approach for the restore process.

5. Share this information with the `execute` API:
   - **Upon a successful response, `consume the purchase`**.
   - Refresh the courses.

6. In case of a restore (payment done, but execute API or consume not called):
   - For Execute:
      - Leverage the existing mechanism for execute.
      - Integrate consumption following the above approach.
   - **For Consume (when execute is called but the product isn't consumed):
      - Proceed with the consumption straightforwardly.
      - The course is already verified from the server and locally.**

7. Tada!!

### References

- [Obfuscated Profile ID](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setObfuscatedProfileId(java.lang.String))
- [Purchase States](https://developer.android.com/reference/com/android/billingclient/api/Purchase.PurchaseState)