### PR TITLE
fix: App crash on primary email change from web

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/authenticator/OauthRefreshTokenAuthenticator.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/authenticator/OauthRefreshTokenAuthenticator.kt
@@ -79,6 +79,7 @@ class OauthRefreshTokenAuthenticator @Inject constructor(
                     requestBuilder.build()
                 }
             }
+
             TOKEN_NONEXISTENT_ERROR_MESSAGE,
             TOKEN_INVALID_GRANT_ERROR_MESSAGE,
             JWT_INVALID_TOKEN -> {
@@ -102,8 +103,10 @@ class OauthRefreshTokenAuthenticator @Inject constructor(
                  */
                 EventBus.getDefault().post(LogoutEvent())
             }
+
             DISABLED_USER_ERROR_MESSAGE,
-            JWT_DISABLED_USER_ERROR_MESSAGE -> {
+            JWT_DISABLED_USER_ERROR_MESSAGE,
+            JWT_USER_EMAIL_MISMATCH -> {
                 EventBus.getDefault().post(LogoutEvent())
             }
         }
@@ -239,6 +242,8 @@ class OauthRefreshTokenAuthenticator @Inject constructor(
         private const val JWT_DISABLED_USER_ERROR_MESSAGE = "User account is disabled."
         private const val JWT_TOKEN_EXPIRED = "Token has expired."
         private const val JWT_INVALID_TOKEN = "Invalid token."
+        private const val JWT_USER_EMAIL_MISMATCH =
+            "Failing JWT authentication due to jwt user email mismatch with lms user email."
 
         /**
          * [REFRESH_TOKEN_EXPIRY_THRESHOLD] behave as a buffer time to be used in the expiry

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/authenticator/OauthRefreshTokenAuthenticator.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/authenticator/OauthRefreshTokenAuthenticator.kt
@@ -59,16 +59,15 @@ class OauthRefreshTokenAuthenticator @Inject constructor(
 
     @Synchronized
     override fun authenticate(route: Route?, response: Response): Request? {
-        logger.warn(response.toString())
+        val responseBody = response.peekBody(Long.MAX_VALUE).string()
+        logger.warn(responseBody)
 
         val currentAuth = loginPrefs.get().currentAuth
         if (currentAuth?.refresh_token == null) {
             return null
         }
 
-        val errorCode = response.body?.let {
-            getErrorCode(it.string(), currentAuth.token_type)
-        } ?: return null
+        val errorCode = getErrorCode(responseBody, currentAuth.token_type) ?: return null
 
         when (errorCode) {
             TOKEN_EXPIRED_ERROR_MESSAGE,


### PR DESCRIPTION
### Description

[LEARNER-9831](https://2u-internal.atlassian.net/browse/LEARNER-9831)

- Force logout the Learner on primary email change from other sessions.
- Replace `response.toString()` with `response.peekBody(Long.MAX_VALUE).string()`.
Ref: https://stackoverflow.com/a/60750929

#### How to test
- Login in the app.
- Use the user and  Login on the web.
- Change the primary email from the web `Account Settings` screen.
- Pull to refresh the app to refresh the screen.
- The app should force logout the user cuz the session expired by the server on the change of primary email.

#### Acceptance Criteria
- The app shouldn't crash at any point cuz of the primary email change.