### PR TITLE
fix: TransactionTooLarge Exception caused by FragmentStateAdapter

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsDashboardFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsDashboardFragment.kt
@@ -519,10 +519,6 @@ class CourseTabsDashboardFragment : BaseFragment() {
         ) { tab: TabLayout.Tab, position: Int ->
             tab.text = courseTabItems[position].title
         }.attach()
-
-        if (courseTabItems.size - 1 > 1) {
-            binding.pager.offscreenPageLimit = courseTabItems.size - 1
-        }
     }
 
     private fun setupToolbar(hasAccess: Boolean) {


### PR DESCRIPTION
### Description

[LEARNER-9897](https://2u-internal.atlassian.net/browse/LEARNER-9897)

Previously, the `FragmentStateAdapter` was saving the state of the course dashboard view pager tabs upon navigation to the `NavigationActivity`. This behavior resulted in a `TransactionTooLarge Exception` when attempting to save the state in the bundle.

To mitigate this issue, we've made adjustments to the caching mechanism of the `ViewPager2`. Specifically, we've set the OffPage limit of the viewPager to `ViewPager2.OFFSCREEN_PAGE_LIMIT_DEFAULT`, which leverages the default caching mechanism of `RecyclerView`. This modification ensures efficient state handling and resolves the encountered exception.
