### PR TITLE
refactor: In-App Purchase Execute API after Backend Changes

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/InAppPurchasesAPI.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/InAppPurchasesAPI.kt
@@ -24,14 +24,12 @@ class InAppPurchasesAPI @Inject constructor(private val iapService: InAppPurchas
 
     fun executeOrder(
         basketId: Long,
-        productId: String,
         purchaseToken: String,
         price: Double,
         currencyCode: String,
     ): Call<ExecuteOrderResponse> {
         return iapService.executeOrder(
             basketId = basketId,
-            productId = productId,
             paymentProcessor = ApiConstants.PAYMENT_PROCESSOR,
             purchaseToken = purchaseToken,
             price = price,

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/InAppPurchasesService.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/InAppPurchasesService.kt
@@ -43,9 +43,8 @@ interface InAppPurchasesService {
     @POST("/api/iap/v1/execute/")
     fun executeOrder(
         @Field("basket_id") basketId: Long,
-        @Field("productId") productId: String,
         @Field("payment_processor") paymentProcessor: String,
-        @Field("purchaseToken") purchaseToken: String,
+        @Field("purchase_token") purchaseToken: String,
         @Field("price") price: Double,
         @Field("currency_code") currencyCode: String,
     ): Call<ExecuteOrderResponse>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/repository/InAppPurchasesRepository.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/repository/InAppPurchasesRepository.kt
@@ -45,7 +45,6 @@ class InAppPurchasesRepository(private var iapAPI: InAppPurchasesAPI) {
 
     fun executeOrder(
         basketId: Long,
-        productId: String,
         purchaseToken: String,
         price: Double,
         currencyCode: String,
@@ -53,7 +52,6 @@ class InAppPurchasesRepository(private var iapAPI: InAppPurchasesAPI) {
     ) {
         iapAPI.executeOrder(
             basketId = basketId,
-            productId = productId,
             purchaseToken = purchaseToken,
             price = price,
             currencyCode = currencyCode,

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/InAppPurchasesViewModel.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/viewModel/InAppPurchasesViewModel.kt
@@ -203,7 +203,6 @@ class InAppPurchasesViewModel @Inject constructor(
             this.iapFlowData = iapData
             repository.executeOrder(
                 basketId = iapData.basketId,
-                productId = iapData.productInfo.courseSku,
                 purchaseToken = iapData.purchaseToken,
                 price = iapData.price,
                 currencyCode = iapData.currencyCode,


### PR DESCRIPTION
### Description

[LEARNER-9937](https://2u-internal.atlassian.net/browse/LEARNER-9937)

- Modify the `purchaseToken` parameter to `purchase_token` in the execute API.
- Remove the `productId` parameter from the execute API.

### Testing
- [ ] Run a complete in-app purchase flow on the staging environment
